### PR TITLE
Skill popover trigger on focus and 4k screen canvas fix

### DIFF
--- a/src/components/Layouts/Canvas/drawCanvas.tsx
+++ b/src/components/Layouts/Canvas/drawCanvas.tsx
@@ -25,7 +25,7 @@ const DrawMap: React.FC<PikasoMapProps> = ({
 }) => {
   const rescaleEditor = () => {
     if (!pikasoEditor) return
-    const scaleSize = Math.round(window.screen.width * 0.5)
+    const scaleSize = Math.round(window.innerWidth * 0.8)
     pikasoEditor?.board.stage.setSize({width: scaleSize, height: scaleSize}) 
     pikasoEditor?.board.rescale()
   }

--- a/src/components/Layouts/Canvas/mapCanvas.tsx
+++ b/src/components/Layouts/Canvas/mapCanvas.tsx
@@ -13,7 +13,7 @@ interface PikasoMapProps {
 const MapCanvas: React.FC<PikasoMapProps> = ({ pikasoRef, pikasoEditor, currentMap, style, setCurrentMap }) => {
   const rescaleEditor = () => {
     if (!pikasoEditor) return
-    const scaleSize = Math.round(window.screen.width * 0.5)
+    const scaleSize = Math.round(window.innerWidth * 0.8)
     pikasoEditor?.board.stage.setSize({width: scaleSize, height: scaleSize})
 
     const image = new Image()

--- a/src/components/Layouts/Sider/SiderItem.tsx
+++ b/src/components/Layouts/Sider/SiderItem.tsx
@@ -36,7 +36,7 @@ export const CharacterSiderItem: React.FC<CharacterSiderItemProps> = ({ data, si
 
   return (
     <Popover
-      position='rightTop'
+      position='rightTop' trigger='focus'
       content={<Card style={{ width: '500px', height: "100%", margin: "0 auto", overflow: "hidden" }}>
         <div style={{ display: "flex", height: "100%" }}>
           <div style={{ height: "360px", width: "200px", margin: "0 auto" }}>


### PR DESCRIPTION

https://github.com/user-attachments/assets/5da99270-da9c-43d2-992e-4fcd93f16c6c

also fixed an issue that made the dragged icons 2x smaller scale when using 4k with window half the window size

