### PR TITLE
Tuning prettier config and format codes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+electron
+docs
+.github

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=38C2FF&width=435&lines=Map+Marking;Strategy+Discussing;Lineup+Learning)](https://git.io/typing-svg)
 
-![Static Badge](https://img.shields.io/badge/React.js-blue)  ![Static Badge](https://img.shields.io/badge/Typescript-blue)  ![Static Badge](https://img.shields.io/badge/License-GPL3.0-orange)
+![Static Badge](https://img.shields.io/badge/React.js-blue) ![Static Badge](https://img.shields.io/badge/Typescript-blue)![Static Badge](https://img.shields.io/badge/License-GPL3.0-orange)
 
 [**Strinova Map Assistant (fsltech.cn)**](https://strinova.fsltech.cn/)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   { ignores: ['dist'] },
@@ -25,4 +25,4 @@ export default tseslint.config(
       ],
     },
   },
-)
+);

--- a/index.html
+++ b/index.html
@@ -1,24 +1,40 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale=0.5, user-scalable=no" />
+    <title>Strinova Map Assistant</title>
+    <script type="text/javascript">
+      (function (c, l, a, r, i, t, y) {
+        c[a] =
+          c[a] ||
+          function () {
+            (c[a].q = c[a].q || []).push(arguments);
+          };
+        t = l.createElement(r);
+        t.async = 1;
+        t.src = 'https://www.clarity.ms/tag/' + i;
+        y = l.getElementsByTagName(r)[0];
+        y.parentNode.insertBefore(t, y);
+      })(window, document, 'clarity', 'script', 'obpvx4i33b');
+    </script>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=0.5, user-scalable=no" />
-  <title>Strinova Map Assistant</title>
-  <script type="text/javascript">
-    (function (c, l, a, r, i, t, y) {
-      c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
-      t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
-      y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
-    })(window, document, "clarity", "script", "obpvx4i33b");
-  </script>
-</head>
-
-<body>
-  <div id="root" ref="capture"
-    style="max-width: 100svw;min-width: -webkit-fill-available;min-width:-moz-available;width: 100%;display: flex;overflow: hidden;scrollbar-width: none;">
-  </div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div
+      id="root"
+      ref="capture"
+      style="
+        max-width: 100svw;
+        min-width: -webkit-fill-available;
+        min-width: -moz-available;
+        width: 100%;
+        display: flex;
+        overflow: hidden;
+        scrollbar-width: none;
+      "></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -42,11 +42,9 @@
     "singleQuote": true,
     "bracketSameLine": true,
     "endOfLine": "auto",
-    "trailingComma": "none",
-    "semi": false,
-    "jsxSingleQuote": true,
-    "printWidth": 120,
-    "tabWidth": 2
+    "trailingComma": "all",
+    "semi": true,
+    "jsxSingleQuote": true
   },
   "volta": {
     "node": "22.14.0",

--- a/src/App.css
+++ b/src/App.css
@@ -21,7 +21,7 @@ body::-webkit-scrollbar {
   /* 对于Firefox浏览器，隐藏滚动条 */
 }
 
-.no-select{
+.no-select {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,46 @@
-import React, { useLayoutEffect, useState } from 'react'
-import { Spin } from '@douyinfe/semi-ui'
-import './index.css'
-import './App.css'
-import { characterRegistry, loadAllCharacters } from './data/characters/characterRegistry'
-import AppShell from './components/appShell'
+import React, { useLayoutEffect, useState } from 'react';
+import { Spin } from '@douyinfe/semi-ui';
+import './index.css';
+import './App.css';
+import {
+  characterRegistry,
+  loadAllCharacters,
+} from './data/characters/characterRegistry';
+import AppShell from './components/appShell';
 
 const App: React.FC = () => {
-  const [characterData, setCharacterData] = useState<characterRegistry | null>(null)
+  const [characterData, setCharacterData] = useState<characterRegistry | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
 
   useLayoutEffect(() => {
     if (!characterData) {
-      loadAllCharacters().then(data => {
-        setCharacterData(data)
-        console.log(characterData)
+      loadAllCharacters().then((data) => {
+        setCharacterData(data);
+        console.log(characterData);
         setLoading(false);
       });
     }
-  }, [setCharacterData, characterData])
+  }, [setCharacterData, characterData]);
 
   if (loading) {
     return (
-      <div className='minHeightAvailable' style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100svh', width: '100%' }}>
+      <div
+        className='minHeightAvailable'
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100svh',
+          width: '100%',
+        }}>
         <Spin size='large' />
       </div>
-    )
+    );
   }
 
-  return (
-    <AppShell characterData={characterData!} />
-  )
-}
+  return <AppShell characterData={characterData!} />;
+};
 
-export default App
+export default App;

--- a/src/components/Layouts/Buttons/skill-normal-button.tsx
+++ b/src/components/Layouts/Buttons/skill-normal-button.tsx
@@ -1,37 +1,38 @@
-import { Button } from '@douyinfe/semi-ui'
-import React, { forwardRef } from 'react'
-import type { sideData } from '../../../data/characters/characterRegistry'
+import { Button } from '@douyinfe/semi-ui';
+import React, { forwardRef } from 'react';
+import type { sideData } from '../../../data/characters/characterRegistry';
 interface StandardButtonProps {
-  sideData: sideData
-  onClick: () => void
+  sideData: sideData;
+  onClick: () => void;
 }
 
-const SkillNormalButton: React.FC<StandardButtonProps> = forwardRef<Button, StandardButtonProps>(
-  ({ onClick, sideData }, ref) => {
-
-    const buttons = Object.keys(sideData!.skills).map((key) => {
-      return (
-        <Button
-          ref={ref}
-          key={key}
-          style={{
-            width: '4rem',
-            height: '4rem',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center'
-          }}
-          onClick={() => onClick()}>
-          <img width={'100%'} height={'100%'} src={sideData.skills[key as keyof typeof sideData.skills].skillIcon} alt={key} />
-        </Button>
-      )
-    })
+const SkillNormalButton: React.FC<StandardButtonProps> = forwardRef<
+  Button,
+  StandardButtonProps
+>(({ onClick, sideData }, ref) => {
+  const buttons = Object.keys(sideData!.skills).map((key) => {
     return (
-      <div>
-        {buttons}
-      </div>
-    )
-  }
-)
+      <Button
+        ref={ref}
+        key={key}
+        style={{
+          width: '4rem',
+          height: '4rem',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+        onClick={() => onClick()}>
+        <img
+          width={'100%'}
+          height={'100%'}
+          src={sideData.skills[key as keyof typeof sideData.skills].skillIcon}
+          alt={key}
+        />
+      </Button>
+    );
+  });
+  return <div>{buttons}</div>;
+});
 
-export default SkillNormalButton
+export default SkillNormalButton;

--- a/src/components/Layouts/Buttons/tool-color-button.tsx
+++ b/src/components/Layouts/Buttons/tool-color-button.tsx
@@ -1,23 +1,25 @@
-import { Button } from '@douyinfe/semi-ui'
-import { forwardRef } from 'react'
+import { Button } from '@douyinfe/semi-ui';
+import { forwardRef } from 'react';
 
 interface ToolColorButtonProps {
-  color: string
-  onClick: (value: string) => void
-  text: string
+  color: string;
+  onClick: (value: string) => void;
+  text: string;
 }
 
-const ToolColorButton = forwardRef<Button, ToolColorButtonProps>(({ color, onClick, text }, ref) => {
-  return (
-    <Button
-      key={text}
-      ref={ref}
-      color={color}
-      theme={'solid'}
-      size='small'
-      style={{ width: '3rem', height: '3rem', background: color }}
-      onClick={() => onClick(color)}></Button>
-  )
-})
+const ToolColorButton = forwardRef<Button, ToolColorButtonProps>(
+  ({ color, onClick, text }, ref) => {
+    return (
+      <Button
+        key={text}
+        ref={ref}
+        color={color}
+        theme={'solid'}
+        size='small'
+        style={{ width: '3rem', height: '3rem', background: color }}
+        onClick={() => onClick(color)}></Button>
+    );
+  },
+);
 
-export default ToolColorButton
+export default ToolColorButton;

--- a/src/components/Layouts/Buttons/tool-normal-button.tsx
+++ b/src/components/Layouts/Buttons/tool-normal-button.tsx
@@ -1,28 +1,31 @@
-import { Button } from '@douyinfe/semi-ui'
-import { Type } from '@douyinfe/semi-ui/lib/es/button'
-import React, { forwardRef } from 'react'
-import { IconType } from 'react-icons'
+import { Button } from '@douyinfe/semi-ui';
+import { Type } from '@douyinfe/semi-ui/lib/es/button';
+import React, { forwardRef } from 'react';
+import { IconType } from 'react-icons';
 
 interface StandardButtonProps {
-  Icon: IconType
-  isActiveTool: boolean
-  onClick: () => void
+  Icon: IconType;
+  isActiveTool: boolean;
+  onClick: () => void;
   typeOverride?: Type;
 }
 
-const toolNormalButton: React.FC<StandardButtonProps> = forwardRef<Button, StandardButtonProps>(
-  ({ Icon, isActiveTool, onClick, typeOverride }, ref) => {
-    return (
-      <Button
-        ref={ref}
-        icon={<Icon size={'2rem'} />}
-        size='large'
-        style={{ width: '100%', height: '4rem' }}
-        type={typeOverride ? typeOverride : isActiveTool ? 'secondary' : 'tertiary'}
-        onClick={onClick}
-      />
-    )
-  }
-)
+const toolNormalButton: React.FC<StandardButtonProps> = forwardRef<
+  Button,
+  StandardButtonProps
+>(({ Icon, isActiveTool, onClick, typeOverride }, ref) => {
+  return (
+    <Button
+      ref={ref}
+      icon={<Icon size={'2rem'} />}
+      size='large'
+      style={{ width: '100%', height: '4rem' }}
+      type={
+        typeOverride ? typeOverride : isActiveTool ? 'secondary' : 'tertiary'
+      }
+      onClick={onClick}
+    />
+  );
+});
 
-export default toolNormalButton
+export default toolNormalButton;

--- a/src/components/Layouts/Buttons/tool-popover-button.tsx
+++ b/src/components/Layouts/Buttons/tool-popover-button.tsx
@@ -1,28 +1,33 @@
-import { Button, Popover, Slider } from '@douyinfe/semi-ui'
-import React from 'react'
-import { MdCreate } from 'react-icons/md'
+import { Button, Popover, Slider } from '@douyinfe/semi-ui';
+import React from 'react';
+import { MdCreate } from 'react-icons/md';
 
 interface StandardButtonProps {
-  icon: typeof MdCreate
-  penWidth: number
-  setpenWidth: React.Dispatch<React.SetStateAction<number>>
-  penColor: string
-  isActiveTool: boolean
-  onClick: () => void
+  icon: typeof MdCreate;
+  penWidth: number;
+  setpenWidth: React.Dispatch<React.SetStateAction<number>>;
+  penColor: string;
+  isActiveTool: boolean;
+  onClick: () => void;
 }
 
 const toolPopoverButton: React.FC<StandardButtonProps> = (props) => {
   const markPlate = (
     <div
       className='grid grid-flex'
-      style={{ width: '280px', height: '50px', display: 'flex', justifyContent: 'space-around' }}>
+      style={{
+        width: '280px',
+        height: '50px',
+        display: 'flex',
+        justifyContent: 'space-around',
+      }}>
       <Slider
         style={{ marginTop: '8px', marginLeft: '10px', width: '200px' }}
         min={1}
         max={5}
         defaultValue={props.penWidth}
         onChange={(value) => {
-          props.setpenWidth(value as number)
+          props.setpenWidth(value as number);
         }}></Slider>
       <div
         style={{
@@ -34,10 +39,10 @@ const toolPopoverButton: React.FC<StandardButtonProps> = (props) => {
           placeItems: 'center',
           placeContent: 'center',
           backgroundColor: props.penColor,
-          overflow: 'hidden'
+          overflow: 'hidden',
         }}></div>
     </div>
-  )
+  );
 
   return (
     <Popover content={markPlate} position={'left'}>
@@ -49,7 +54,7 @@ const toolPopoverButton: React.FC<StandardButtonProps> = (props) => {
         onClick={props.onClick}
       />
     </Popover>
-  )
-}
+  );
+};
 
-export default toolPopoverButton
+export default toolPopoverButton;

--- a/src/components/Layouts/Buttons/tool-popover-text-button.tsx
+++ b/src/components/Layouts/Buttons/tool-popover-text-button.tsx
@@ -1,28 +1,33 @@
-import { Button, Popover, Slider } from '@douyinfe/semi-ui'
-import React from 'react'
-import { MdCreate } from 'react-icons/md'
+import { Button, Popover, Slider } from '@douyinfe/semi-ui';
+import React from 'react';
+import { MdCreate } from 'react-icons/md';
 
 interface StandardButtonProps {
-  icon: typeof MdCreate
-  penWidth: number
-  setpenWidth: React.Dispatch<React.SetStateAction<number>>
-  penColor: string
-  isActiveTool: boolean
-  onClick: () => void
+  icon: typeof MdCreate;
+  penWidth: number;
+  setpenWidth: React.Dispatch<React.SetStateAction<number>>;
+  penColor: string;
+  isActiveTool: boolean;
+  onClick: () => void;
 }
 
 const toolTextPopoverButton: React.FC<StandardButtonProps> = (props) => {
   const markPlate = (
     <div
       className='grid grid-flex'
-      style={{ width: '300px', height: '70px', display: 'flex', justifyContent: 'space-around' }}>
+      style={{
+        width: '300px',
+        height: '70px',
+        display: 'flex',
+        justifyContent: 'space-around',
+      }}>
       <Slider
-        style={{ marginLeft: '8px', marginTop: "20px", width: '200px' }}
+        style={{ marginLeft: '8px', marginTop: '20px', width: '200px' }}
         min={1}
         max={5}
         defaultValue={props.penWidth}
         onChange={(value) => {
-          props.setpenWidth(value as number)
+          props.setpenWidth(value as number);
         }}></Slider>
       <div
         style={{
@@ -33,10 +38,12 @@ const toolTextPopoverButton: React.FC<StandardButtonProps> = (props) => {
           placeItems: 'center',
           placeContent: 'center',
           color: props.penColor,
-          overflow: 'hidden'
-        }}>A</div>
+          overflow: 'hidden',
+        }}>
+        A
+      </div>
     </div>
-  )
+  );
 
   return (
     <Popover content={markPlate} position={'left'}>
@@ -48,7 +55,7 @@ const toolTextPopoverButton: React.FC<StandardButtonProps> = (props) => {
         onClick={props.onClick}
       />
     </Popover>
-  )
-}
+  );
+};
 
-export default toolTextPopoverButton
+export default toolTextPopoverButton;

--- a/src/components/Layouts/Canvas/drawCanvas.tsx
+++ b/src/components/Layouts/Canvas/drawCanvas.tsx
@@ -1,20 +1,20 @@
-import React, { useLayoutEffect } from 'react'
-import { DrawType, Pikaso, type BaseShapes } from 'pikaso'
-import { mapTools } from '../../../utils/canvasConstants'
-import { getDragValue, setDragValue } from '../../../data/dragAndDrop.ts'
+import React, { useLayoutEffect } from 'react';
+import { DrawType, Pikaso, type BaseShapes } from 'pikaso';
+import { mapTools } from '../../../utils/canvasConstants';
+import { getDragValue, setDragValue } from '../../../data/dragAndDrop.ts';
 
 interface PikasoMapProps {
-  pikasoRef: React.RefObject<HTMLDivElement>
-  pikasoEditor: Pikaso<BaseShapes> | null
-  currentMap: string
-  penColor: string
-  canvasTool: mapTools
-  setTool: React.Dispatch<React.SetStateAction<mapTools>>
-  penWidth: number
-  lineWidth: number
-  fontSize: number
-  panelcollaps: boolean
-  load: React.Dispatch<React.SetStateAction<void>>
+  pikasoRef: React.RefObject<HTMLDivElement>;
+  pikasoEditor: Pikaso<BaseShapes> | null;
+  currentMap: string;
+  penColor: string;
+  canvasTool: mapTools;
+  setTool: React.Dispatch<React.SetStateAction<mapTools>>;
+  penWidth: number;
+  lineWidth: number;
+  fontSize: number;
+  panelcollaps: boolean;
+  load: React.Dispatch<React.SetStateAction<void>>;
 }
 
 const DrawMap: React.FC<PikasoMapProps> = ({
@@ -28,47 +28,50 @@ const DrawMap: React.FC<PikasoMapProps> = ({
   lineWidth,
   fontSize,
   panelcollaps,
-  load
+  load,
 }) => {
-  let rescaleTO: any
+  let rescaleTO: any;
   const rescaleEditor = (timeout: number = 0) => {
-    clearTimeout(rescaleTO)
+    clearTimeout(rescaleTO);
     rescaleTO = setTimeout(() => {
       requestAnimationFrame(() => {
-        if (!pikasoEditor) return
-        const scaleSize = 1000
-        pikasoEditor?.board.stage.setSize({width: scaleSize, height: scaleSize}) 
-        pikasoEditor?.board.rescale()
-      })
-    },timeout)
-  }
+        if (!pikasoEditor) return;
+        const scaleSize = 1000;
+        pikasoEditor?.board.stage.setSize({
+          width: scaleSize,
+          height: scaleSize,
+        });
+        pikasoEditor?.board.rescale();
+      });
+    }, timeout);
+  };
 
   useLayoutEffect(() => {
     switch (canvasTool) {
       case DrawType.Arrow:
         pikasoEditor?.shapes.arrow.draw({
           stroke: penColor,
-          strokeWidth: lineWidth
-        })
-        break
+          strokeWidth: lineWidth,
+        });
+        break;
       case DrawType.Line:
         pikasoEditor?.shapes.line.draw({
           stroke: penColor,
-          strokeWidth: lineWidth
-        })
-        break
+          strokeWidth: lineWidth,
+        });
+        break;
       case DrawType.Pencil:
         pikasoEditor?.shapes.pencil.draw({
           stroke: penColor,
-          strokeWidth: penWidth
-        })
-        break
+          strokeWidth: penWidth,
+        });
+        break;
       case 'SELECT':
-        pikasoEditor?.shapes.pencil.stopDrawing()
-        break
+        pikasoEditor?.shapes.pencil.stopDrawing();
+        break;
       case 'TEXT':
-        pikasoEditor?.shapes.pencil.stopDrawing()
-        break
+        pikasoEditor?.shapes.pencil.stopDrawing();
+        break;
     }
   }, [
     currentMap,
@@ -83,124 +86,141 @@ const DrawMap: React.FC<PikasoMapProps> = ({
     pikasoEditor?.shapes.line,
     pikasoEditor?.shapes.pencil,
     pikasoEditor?.shapes.arrow,
-  ])
+  ]);
 
   useLayoutEffect(() => {
-    rescaleEditor()
-    window.addEventListener('resize', ()=>rescaleEditor())
+    rescaleEditor();
+    window.addEventListener('resize', () => rescaleEditor());
     return () => {
-      window.removeEventListener('resize', ()=>rescaleEditor())
-    }
-  }, [
-    currentMap,
-    pikasoEditor?.board.background,
-  ])
+      window.removeEventListener('resize', () => rescaleEditor());
+    };
+  }, [currentMap, pikasoEditor?.board.background]);
 
   useLayoutEffect(() => {
-    rescaleEditor(100)
-  }, [panelcollaps])
+    rescaleEditor(100);
+  }, [panelcollaps]);
 
-  const handleCanvasMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  const handleCanvasMouseDown = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
     switch (canvasTool) {
       case DrawType.Line:
-        pikasoEditor?.shapes.line.stopDrawing()
+        pikasoEditor?.shapes.line.stopDrawing();
         pikasoEditor?.shapes.line.draw({
           stroke: penColor,
-          strokeWidth: lineWidth
-        })
-        break
+          strokeWidth: lineWidth,
+        });
+        break;
       case DrawType.Arrow:
-        pikasoEditor?.shapes.arrow.stopDrawing()
+        pikasoEditor?.shapes.arrow.stopDrawing();
         pikasoEditor?.shapes.arrow.draw({
           stroke: penColor,
-          strokeWidth: lineWidth
-        })
-        break
+          strokeWidth: lineWidth,
+        });
+        break;
       case DrawType.Pencil:
-        pikasoEditor?.shapes.pencil.stopDrawing()
+        pikasoEditor?.shapes.pencil.stopDrawing();
         pikasoEditor?.shapes.pencil.draw({
           stroke: penColor,
-          strokeWidth: penWidth
-        })
-        break
+          strokeWidth: penWidth,
+        });
+        break;
       case 'SELECT':
-        pikasoEditor?.shapes.pencil.stopDrawing()
-        break
+        pikasoEditor?.shapes.pencil.stopDrawing();
+        break;
       case 'TEXT':
-        pikasoEditor?.shapes.pencil.stopDrawing()
-        const rect = (e.target as HTMLCanvasElement)?.getBoundingClientRect()
-        const pikasoSize = pikasoEditor?.board.stage.getSize()
-        const scale = { x: pikasoSize!.width / rect!.width, y: pikasoSize!.height / rect!.height }
-        const diff = { x: e.clientX - rect!.left, y: e.clientY - rect!.top }
-        const textPos = { x: diff.x * scale.x, y: diff.y * scale.y }
+        pikasoEditor?.shapes.pencil.stopDrawing();
+        const rect = (e.target as HTMLCanvasElement)?.getBoundingClientRect();
+        const pikasoSize = pikasoEditor?.board.stage.getSize();
+        const scale = {
+          x: pikasoSize!.width / rect!.width,
+          y: pikasoSize!.height / rect!.height,
+        };
+        const diff = { x: e.clientX - rect!.left, y: e.clientY - rect!.top };
+        const textPos = { x: diff.x * scale.x, y: diff.y * scale.y };
 
         const label = pikasoEditor?.shapes.label.insert({
           container: {
             x: textPos.x,
-            y: textPos.y
+            y: textPos.y,
           },
           text: {
             text: 'Type here',
             fill: penColor,
-            fontSize: fontSize * 16
-          }
-        })
-        label?.select()
-        setTool('SELECT')
-        break
+            fontSize: fontSize * 16,
+          },
+        });
+        label?.select();
+        setTool('SELECT');
+        break;
     }
-  }
+  };
 
-  const handleOnDrop = (e: React.DragEvent<HTMLDivElement>| any) => {
-    const dragValue = getDragValue()
-    const imgLink = dragValue?.type == 'imageLink' ? dragValue.value : null
-    if(imgLink) {
-      const img = new Image()
-      img.src = imgLink
+  const handleOnDrop = (e: React.DragEvent<HTMLDivElement> | any) => {
+    const dragValue = getDragValue();
+    const imgLink = dragValue?.type == 'imageLink' ? dragValue.value : null;
+    if (imgLink) {
+      const img = new Image();
+      img.src = imgLink;
       img.onload = () => {
-        const size = 35
-        const ratio = img.width / img.height
+        const size = 35;
+        const ratio = img.width / img.height;
 
-        const clientPos = e.clientX ? e : e.changedTouches[0]
-        const rect = (e.target as HTMLCanvasElement)?.getBoundingClientRect()
-        const pikasoSize = pikasoEditor?.board.stage.getSize()
-        const scale = { x: pikasoSize!.width / rect!.width, y: pikasoSize!.height / rect!.height }
-        const diff = { x: clientPos.clientX - rect!.left, y: clientPos.clientY - rect!.top }
-        const imgPos = { x: diff.x * scale.x, y: diff.y * scale.y }
-  
+        const clientPos = e.clientX ? e : e.changedTouches[0];
+        const rect = (e.target as HTMLCanvasElement)?.getBoundingClientRect();
+        const pikasoSize = pikasoEditor?.board.stage.getSize();
+        const scale = {
+          x: pikasoSize!.width / rect!.width,
+          y: pikasoSize!.height / rect!.height,
+        };
+        const diff = {
+          x: clientPos.clientX - rect!.left,
+          y: clientPos.clientY - rect!.top,
+        };
+        const imgPos = { x: diff.x * scale.x, y: diff.y * scale.y };
+
         pikasoEditor?.shapes.image.insert(imgLink, {
           x: imgPos.x - size / 2,
           y: imgPos.y - size / 2,
           width: size * ratio,
-          height: size
-        })
-      }
-    } else if(e.dataTransfer && e.dataTransfer.files[0]?.type == 'application/json') {
+          height: size,
+        });
+      };
+    } else if (
+      e.dataTransfer &&
+      e.dataTransfer.files[0]?.type == 'application/json'
+    ) {
       let reader = new FileReader();
-      reader.onload = function(re) {
+      reader.onload = function (re) {
         const json = JSON.parse(re.target!.result as string);
-        load(json)
+        load(json);
       };
       reader.readAsText(e.dataTransfer.files[0]);
-      e.preventDefault()
+      e.preventDefault();
     }
-    setDragValue(null)
-  }
+    setDragValue(null);
+  };
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-  }
+    e.preventDefault();
+  };
 
   return (
     <div
       ref={pikasoRef}
-      style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      }}
       className='drawCanvas'
       onDrop={handleOnDrop}
       onTouchEnd={handleOnDrop}
       onDragOver={handleDragOver}
       onClick={handleCanvasMouseDown}></div>
-  )
-}
+  );
+};
 
-export default DrawMap
+export default DrawMap;

--- a/src/components/Layouts/Canvas/mapCanvas.tsx
+++ b/src/components/Layouts/Canvas/mapCanvas.tsx
@@ -1,62 +1,67 @@
-import React, { useLayoutEffect } from 'react'
-import { Pikaso, type BaseShapes } from 'pikaso'
+import React, { useLayoutEffect } from 'react';
+import { Pikaso, type BaseShapes } from 'pikaso';
 
 interface PikasoMapProps {
-  pikasoRef: React.RefObject<HTMLDivElement>
-  pikasoEditor: Pikaso<BaseShapes> | null
-  currentMap: string
-  style?: React.CSSProperties
-  panelcollaps: boolean
+  pikasoRef: React.RefObject<HTMLDivElement>;
+  pikasoEditor: Pikaso<BaseShapes> | null;
+  currentMap: string;
+  style?: React.CSSProperties;
+  panelcollaps: boolean;
 }
 
-const MapCanvas: React.FC<PikasoMapProps> = ({ pikasoRef, pikasoEditor, currentMap, style, panelcollaps }) => {
-  let rescaleTO: any
+const MapCanvas: React.FC<PikasoMapProps> = ({
+  pikasoRef,
+  pikasoEditor,
+  currentMap,
+  style,
+  panelcollaps,
+}) => {
+  let rescaleTO: any;
   const rescaleEditor = (timeout: number = 0) => {
-    clearTimeout(rescaleTO)
+    clearTimeout(rescaleTO);
     rescaleTO = setTimeout(() => {
       requestAnimationFrame(() => {
-        if (!pikasoEditor) return
-        const scaleSize = 1000
-        pikasoEditor?.board.stage.setSize({width: scaleSize, height: scaleSize})
-        pikasoEditor?.board.rescale()
-    
-        const image = new Image()
-        image.src = currentMap
-        
+        if (!pikasoEditor) return;
+        const scaleSize = 1000;
+        pikasoEditor?.board.stage.setSize({
+          width: scaleSize,
+          height: scaleSize,
+        });
+        pikasoEditor?.board.rescale();
+
+        const image = new Image();
+        image.src = currentMap;
+
         image.onload = () => {
-          const scale = image.height / pikasoEditor!.board.stage.height()
+          const scale = image.height / pikasoEditor!.board.stage.height();
           pikasoEditor?.board.background.setImageFromUrl(currentMap, {
             size: 'contain',
-            x: pikasoEditor.board.stage.width() / 2 - image.width / 2 / scale
-          })
+            x: pikasoEditor.board.stage.width() / 2 - image.width / 2 / scale,
+          });
           // pikasoEditor?.board.rescale()
-        }
-      })
-    },timeout)
-  }
+        };
+      });
+    }, timeout);
+  };
 
   useLayoutEffect(() => {
-    rescaleEditor()
-    window.addEventListener('resize', ()=>rescaleEditor())
+    rescaleEditor();
+    window.addEventListener('resize', () => rescaleEditor());
     return () => {
-      window.removeEventListener('resize', ()=>rescaleEditor())
-    }
-  }, [
-    currentMap,
-    pikasoEditor?.board.background,
-  ])
-  
+      window.removeEventListener('resize', () => rescaleEditor());
+    };
+  }, [currentMap, pikasoEditor?.board.background]);
 
   useLayoutEffect(() => {
-    rescaleEditor(100)
-  }, [panelcollaps])
+    rescaleEditor(100);
+  }, [panelcollaps]);
 
   return (
     <div
       ref={pikasoRef}
       style={{ ...style, width: '100%', height: '100%' }}
       className='drawMap'></div>
-  )
-}
+  );
+};
 
-export default MapCanvas
+export default MapCanvas;

--- a/src/components/Layouts/Footer/FooterContent.tsx
+++ b/src/components/Layouts/Footer/FooterContent.tsx
@@ -1,19 +1,43 @@
-import { Popover, Tooltip } from '@douyinfe/semi-ui'
-import React, { useContext } from 'react'
-import { FaGithub, FaDiscord, FaQq } from 'react-icons/fa'
-import ContributeBox from '../../contributors.tsx'
-import SupportUs from './SupportUs.tsx'
-import SiteList from './SiteList.tsx'
-import FriendLink from './FriendLink.tsx'
-import { LanguageContext } from '../../../contexts/LanguageContext.ts'
+import { Popover, Tooltip } from '@douyinfe/semi-ui';
+import React, { useContext } from 'react';
+import { FaGithub, FaDiscord, FaQq } from 'react-icons/fa';
+import ContributeBox from '../../contributors.tsx';
+import SupportUs from './SupportUs.tsx';
+import SiteList from './SiteList.tsx';
+import FriendLink from './FriendLink.tsx';
+import { LanguageContext } from '../../../contexts/LanguageContext.ts';
 
 const FooterContent: React.FC = () => {
-  const currentLanguage = useContext(LanguageContext)
+  const currentLanguage = useContext(LanguageContext);
 
   return (
-    <div className="minWidthAvailable" style={{ marginLeft: '80px', display: 'flex', justifyContent: 'center', alignItems: 'center', overflow: 'auto hidden', maxWidth: '100svw' }}>
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', color: "rgba(var(--semi-grey-9), 1)", height: '4rem' }}>
-        <a href='https://creativecommons.org/licenses/by-nc-sa/4.0/' target='_blank' rel='nofollow' style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+    <div
+      className='minWidthAvailable'
+      style={{
+        marginLeft: '80px',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        overflow: 'auto hidden',
+        maxWidth: '100svw',
+      }}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          color: 'rgba(var(--semi-grey-9), 1)',
+          height: '4rem',
+        }}>
+        <a
+          href='https://creativecommons.org/licenses/by-nc-sa/4.0/'
+          target='_blank'
+          rel='nofollow'
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}>
           <img
             decoding='async'
             loading='lazy'
@@ -23,37 +47,70 @@ const FooterContent: React.FC = () => {
             style={{ marginRight: '20px', marginTop: '5px' }}
           />
         </a>
-        <div style={{ marginBottom: '0px', display: 'flex', flexDirection: 'row', gap: '0.3rem', whiteSpace: 'nowrap' }}>
+        <div
+          style={{
+            marginBottom: '0px',
+            display: 'flex',
+            flexDirection: 'row',
+            gap: '0.3rem',
+            whiteSpace: 'nowrap',
+          }}>
           {'© 番石榴网络科技工作室 & '}
-          <Popover content={<ContributeBox learnmore={currentLanguage.sidebar.learnmore} />} position={'top'}>
+          <Popover
+            content={
+              <ContributeBox learnmore={currentLanguage.sidebar.learnmore} />
+            }
+            position={'top'}>
             <a>Contributors</a>
           </Popover>
         </div>
-        <div style={{ height: 'max', display: 'flex', flexDirection: 'row', alignItems: 'center', marginLeft: '10px', marginTop: '6px' }}>
+        <div
+          style={{
+            height: 'max',
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            marginLeft: '10px',
+            marginTop: '6px',
+          }}>
           <Tooltip content='Github repository'>
-            <a href='https://github.com/fsltech-team/Strinova-Map-Assistant' target='_blank' style={{}}>
+            <a
+              href='https://github.com/fsltech-team/Strinova-Map-Assistant'
+              target='_blank'
+              style={{}}>
               <FaGithub />
             </a>
           </Tooltip>
           <Tooltip content='Discord channel'>
-            <a href='https://discord.gg/Zn6fWgT4Sb' target='_blank' style={{ marginLeft: '5px' }}>
+            <a
+              href='https://discord.gg/Zn6fWgT4Sb'
+              target='_blank'
+              style={{ marginLeft: '5px' }}>
               <FaDiscord />
             </a>
           </Tooltip>
           <Tooltip content='QQ群'>
-            <a href='https://qm.qq.com/q/E96Z4s8eze' target='_blank' style={{ marginLeft: '5px' }}>
+            <a
+              href='https://qm.qq.com/q/E96Z4s8eze'
+              target='_blank'
+              style={{ marginLeft: '5px' }}>
               <FaQq />
             </a>
           </Tooltip>
         </div>
-        <div style={{ marginBottom: '0px', display: 'flex', flexDirection: 'row' }}>
+        <div
+          style={{
+            marginBottom: '0px',
+            display: 'flex',
+            flexDirection: 'row',
+          }}>
           <FriendLink />
           <SiteList />
           <SupportUs />
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default FooterContent
+export default FooterContent;

--- a/src/components/Layouts/Footer/FooterModal.tsx
+++ b/src/components/Layouts/Footer/FooterModal.tsx
@@ -1,13 +1,17 @@
-import { useState } from 'react'
-import { Button, Modal } from '@douyinfe/semi-ui'
+import { useState } from 'react';
+import { Button, Modal } from '@douyinfe/semi-ui';
 
 interface FooterPopupItemProps {
-  icon?: JSX.Element
-  title: string
-  children: JSX.Element
+  icon?: JSX.Element;
+  title: string;
+  children: JSX.Element;
 }
 
-const FooterModal: React.FC<FooterPopupItemProps> = ({ icon, title, children }) => {
+const FooterModal: React.FC<FooterPopupItemProps> = ({
+  icon,
+  title,
+  children,
+}) => {
   const [visible, setVisible] = useState(false);
   const showDialog = () => {
     setVisible(true);
@@ -26,21 +30,21 @@ const FooterModal: React.FC<FooterPopupItemProps> = ({ icon, title, children }) 
 
   return (
     <>
-      <Button onClick={showDialog} style={{ marginLeft: "10px" }}>{icon ? icon : <></>}{title}</Button>
+      <Button onClick={showDialog} style={{ marginLeft: '10px' }}>
+        {icon ? icon : <></>}
+        {title}
+      </Button>
       <Modal
         title={title}
         visible={visible}
         onOk={handleOk}
         afterClose={handleAfterClose} //>=1.16.0
         onCancel={handleCancel}
-        closeOnEsc={true}
-      >
-        <div>
-          {children}
-        </div>
+        closeOnEsc={true}>
+        <div>{children}</div>
       </Modal>
     </>
   );
 };
 
-export default FooterModal
+export default FooterModal;

--- a/src/components/Layouts/Footer/FriendLink.tsx
+++ b/src/components/Layouts/Footer/FriendLink.tsx
@@ -1,13 +1,13 @@
-import { useContext } from 'react'
+import { useContext } from 'react';
 import { Button, Typography, Divider, Row, Col } from '@douyinfe/semi-ui';
-import { LanguageContext } from '../../../contexts/LanguageContext.ts'
-import { FriendLinkForm } from '../../../types/interface'
-import { FaLink } from 'react-icons/fa6'
-import FooterModal from './FooterModal.tsx'
+import { LanguageContext } from '../../../contexts/LanguageContext.ts';
+import { FriendLinkForm } from '../../../types/interface';
+import { FaLink } from 'react-icons/fa6';
+import FooterModal from './FooterModal.tsx';
 
 interface FriendSectionProps {
-  title: string
-  items: FriendLinkForm[]
+  title: string;
+  items: FriendLinkForm[];
 }
 
 const { Title } = Typography;
@@ -17,26 +17,36 @@ const FriendSection: React.FC<FriendSectionProps> = ({ title, items }) => {
     <>
       <Title heading={6}>{title}</Title>
       <Divider margin='12px' />
-      <Row gutter={[0, 10]} style={{ width: "100%", marginTop: "10px" }}>
+      <Row gutter={[0, 10]} style={{ width: '100%', marginTop: '10px' }}>
         {items.map((site, i) => (
           <Col key={i} span={12} style={{}}>
-            <Button size='large' type="tertiary" onClick={() => { open(site.url, "_blank") }} style={{ width: "90%" }}>
-              {site.icon}{site.name}
+            <Button
+              size='large'
+              type='tertiary'
+              onClick={() => {
+                open(site.url, '_blank');
+              }}
+              style={{ width: '90%' }}>
+              {site.icon}
+              {site.name}
             </Button>
           </Col>
         ))}
       </Row>
     </>
-  )
-}
+  );
+};
 
 const FriendLink: React.FC = () => {
-  const lang = useContext(LanguageContext)
-  const langData = lang.friendlinkdata
+  const lang = useContext(LanguageContext);
+  const langData = lang.friendlinkdata;
 
   const children = (
     <>
-      <FriendSection title={langData.classify.official} items={langData.official} />
+      <FriendSection
+        title={langData.classify.official}
+        items={langData.official}
+      />
       <br />
       <FriendSection title={langData.classify.wiki} items={langData.wiki} />
       <br />
@@ -47,7 +57,13 @@ const FriendLink: React.FC = () => {
     </>
   );
 
-  return <FooterModal icon={<FaLink style={{ marginRight: "5px" }} />} title={lang.friendlink} children={children} />
+  return (
+    <FooterModal
+      icon={<FaLink style={{ marginRight: '5px' }} />}
+      title={lang.friendlink}
+      children={children}
+    />
+  );
 };
 
 export default FriendLink;

--- a/src/components/Layouts/Footer/SiteList.tsx
+++ b/src/components/Layouts/Footer/SiteList.tsx
@@ -1,15 +1,15 @@
 import { Button, Typography, Divider, Col, Row } from '@douyinfe/semi-ui';
-import { SiteListForm } from '../../../types/interface'
-import { useContext } from 'react'
-import { LanguageContext } from '../../../contexts/LanguageContext.ts'
-import { IoMdCloudOutline } from "react-icons/io";
-import FooterModal from './FooterModal.tsx'
+import { SiteListForm } from '../../../types/interface';
+import { useContext } from 'react';
+import { LanguageContext } from '../../../contexts/LanguageContext.ts';
+import { IoMdCloudOutline } from 'react-icons/io';
+import FooterModal from './FooterModal.tsx';
 
 const { Title } = Typography;
 
 interface SiteListSectionProps {
-  title: string
-  items: SiteListForm[]
+  title: string;
+  items: SiteListForm[];
 }
 
 const SiteListSection: React.FC<SiteListSectionProps> = ({ title, items }) => {
@@ -17,35 +17,47 @@ const SiteListSection: React.FC<SiteListSectionProps> = ({ title, items }) => {
     <>
       <Title heading={5}>{title}</Title>
       <Divider margin='12px' />
-      <Row gutter={[0, 12]} style={{ width: "100%", marginTop: "10px" }}>
+      <Row gutter={[0, 12]} style={{ width: '100%', marginTop: '10px' }}>
         {items.map((site, i) => (
-          <Col key={i} span={10} style={{ width: "50%" }}>
-            <Button type="tertiary" onClick={() => { open(site.url, "_self") }} style={{ width: "90%" }}>
-              {site.icon}{site.content}
+          <Col key={i} span={10} style={{ width: '50%' }}>
+            <Button
+              type='tertiary'
+              onClick={() => {
+                open(site.url, '_self');
+              }}
+              style={{ width: '90%' }}>
+              {site.icon}
+              {site.content}
             </Button>
           </Col>
         ))}
       </Row>
     </>
-  )
-}
+  );
+};
 
 const SiteList: React.FC = () => {
-  const lang = useContext(LanguageContext)
-  const langData = lang.sitelistdata
+  const lang = useContext(LanguageContext);
+  const langData = lang.sitelistdata;
 
   const children = (
     <>
       {langData.content}
       <br />
-      <SiteListSection title="Global" items={langData.Global} />
+      <SiteListSection title='Global' items={langData.Global} />
       <br />
-      <SiteListSection title="中国节点" items={langData.CN} />
+      <SiteListSection title='中国节点' items={langData.CN} />
       <br />
     </>
   );
 
-  return <FooterModal icon={<IoMdCloudOutline style={{ marginRight: "5px" }} />} title={lang.sitelist} children={children} />
+  return (
+    <FooterModal
+      icon={<IoMdCloudOutline style={{ marginRight: '5px' }} />}
+      title={lang.sitelist}
+      children={children}
+    />
+  );
 };
 
 export default SiteList;

--- a/src/components/Layouts/Footer/SupportUs.tsx
+++ b/src/components/Layouts/Footer/SupportUs.tsx
@@ -1,36 +1,70 @@
-import { useContext } from 'react'
+import { useContext } from 'react';
 import { Typography, Divider } from '@douyinfe/semi-ui';
 import SupportUsList from './SupportUsList.tsx';
-import { LanguageContext } from '../../../contexts/LanguageContext.ts'
-import { IoMdHeart } from "react-icons/io";
-import FooterModal from './FooterModal.tsx'
+import { LanguageContext } from '../../../contexts/LanguageContext.ts';
+import { IoMdHeart } from 'react-icons/io';
+import FooterModal from './FooterModal.tsx';
 
 const { Title } = Typography;
 
 const SupportUs: React.FC = () => {
   const lang = useContext(LanguageContext);
-  const langData = lang.supportusdata
+  const langData = lang.supportusdata;
 
-  const children =  (
+  const children = (
     <>
       {langData.content}
       <SupportUsList />
       <br />
       <Divider margin='12px' />
-      <div><Title heading={6}>{langData.global}</Title></div>
-      <div onClick={() => { open("https://ko-fi.com/MiekoHikari", "_blank") }}>
-        <img src='https://s2.loli.net/2024/10/01/LpQN1lIvu97HdMy.webp' style={{ height: "50px", marginTop: "10px" }} />
+      <div>
+        <Title heading={6}>{langData.global}</Title>
+      </div>
+      <div
+        onClick={() => {
+          open('https://ko-fi.com/MiekoHikari', '_blank');
+        }}>
+        <img
+          src='https://s2.loli.net/2024/10/01/LpQN1lIvu97HdMy.webp'
+          style={{ height: '50px', marginTop: '10px' }}
+        />
       </div>
       <Divider margin='12px' />
-      <div><Title heading={6}>{langData.CN}</Title></div>
-      <div onClick={() => { open("https://afdian.com/a/fsltech", "_blank") }} style={{ display: "flex", height: "50px" }}>
-        <img src='https://s2.loli.net/2024/10/01/Xw74impc6osJDCL.png' style={{ height: "50px", marginTop: "10px", marginLeft: "5px" }} />
-        <div style={{ display: "flex", height: "100%", placeItems: "center", fontSize: "20px", marginLeft: "20px", marginTop: "10px", color: "rgba(var(--semi-grey-9), 1)" }}><strong>爱发电</strong></div>
+      <div>
+        <Title heading={6}>{langData.CN}</Title>
+      </div>
+      <div
+        onClick={() => {
+          open('https://afdian.com/a/fsltech', '_blank');
+        }}
+        style={{ display: 'flex', height: '50px' }}>
+        <img
+          src='https://s2.loli.net/2024/10/01/Xw74impc6osJDCL.png'
+          style={{ height: '50px', marginTop: '10px', marginLeft: '5px' }}
+        />
+        <div
+          style={{
+            display: 'flex',
+            height: '100%',
+            placeItems: 'center',
+            fontSize: '20px',
+            marginLeft: '20px',
+            marginTop: '10px',
+            color: 'rgba(var(--semi-grey-9), 1)',
+          }}>
+          <strong>爱发电</strong>
+        </div>
       </div>
     </>
   );
 
-  return <FooterModal icon={<IoMdHeart style={{marginRight: "5px"}} />} title={lang.sidebar.supportus} children={children} />
+  return (
+    <FooterModal
+      icon={<IoMdHeart style={{ marginRight: '5px' }} />}
+      title={lang.sidebar.supportus}
+      children={children}
+    />
+  );
 };
 
 export default SupportUs;

--- a/src/components/Layouts/Footer/SupportUsList.tsx
+++ b/src/components/Layouts/Footer/SupportUsList.tsx
@@ -1,37 +1,40 @@
-import { useContext } from 'react'
+import { useContext } from 'react';
 import { Button, Typography, Divider, Col, Row } from '@douyinfe/semi-ui';
-import FooterModal from './FooterModal.tsx'
-import { LanguageContext } from '../../../contexts/LanguageContext.ts'
+import FooterModal from './FooterModal.tsx';
+import { LanguageContext } from '../../../contexts/LanguageContext.ts';
 
 const supportlistdata = [
   {
-    name: "秋漫语（asl）",
-    url: ""
+    name: '秋漫语（asl）',
+    url: '',
   },
   {
-    name: "废喵咸鱼TrashMeow",
-    url: "https://space.bilibili.com/24437188"
-  }
-]
+    name: '废喵咸鱼TrashMeow',
+    url: 'https://space.bilibili.com/24437188',
+  },
+];
 
 const { Title } = Typography;
 
 const SupportUsList: React.FC = () => {
-  const lang = useContext(LanguageContext)
-  const langData = lang.supportusdata
+  const lang = useContext(LanguageContext);
+  const langData = lang.supportusdata;
 
   const children = (
     <>
-      <div><Title heading={6}>感谢以下赞助者：</Title></div>
+      <div>
+        <Title heading={6}>感谢以下赞助者：</Title>
+      </div>
       <Divider margin='12px' />
-      <Row gutter={[0, 12]} style={{ width: "100%", marginTop: "10px" }}>
+      <Row gutter={[0, 12]} style={{ width: '100%', marginTop: '10px' }}>
         {supportlistdata.map((data) => (
-          <Col span={6} style={{ width: "50%" }}>
+          <Col span={6} style={{ width: '50%' }}>
             <Button
-              type="tertiary"
-              onClick={() => { if (data.url !== "") open(data.url, "_blank") }}
-              style={{ width: "90%" }}
-            >
+              type='tertiary'
+              onClick={() => {
+                if (data.url !== '') open(data.url, '_blank');
+              }}
+              style={{ width: '90%' }}>
               {data.name}
             </Button>
           </Col>
@@ -40,7 +43,7 @@ const SupportUsList: React.FC = () => {
     </>
   );
 
-  return <FooterModal title={langData.list} children={children} />
+  return <FooterModal title={langData.list} children={children} />;
 };
 
 export default SupportUsList;

--- a/src/components/Layouts/HeaderContent.tsx
+++ b/src/components/Layouts/HeaderContent.tsx
@@ -1,27 +1,35 @@
-import React, { useContext } from 'react'
-import { i18nData } from '../../data/i18n'
-import { Button, Nav, Select, Toast } from '@douyinfe/semi-ui'
-import Title from '@douyinfe/semi-ui/lib/es/typography/title'
-import { MapName } from '../../data/maplist'
-import { MdOutlineTranslate, MdLightMode, MdDarkMode, MdCastConnected, MdContentCopy } from 'react-icons/md'
-import ChangeMapButton from '../buttons/changeMapButton'
-import ChangeHighlightButton from '../buttons/changeHighlightButton'
-import Pikaso, { BaseShapes } from 'pikaso'
-import Announcement from '../announcement'
-import { LanguageContext } from '../../contexts/LanguageContext.ts'
-import { ThemeContext, ThemeType } from '../../contexts/ThemeContext.ts'
-import { Languages } from '../../types/interface.ts'
+import React, { useContext } from 'react';
+import { i18nData } from '../../data/i18n';
+import { Button, Nav, Select, Toast } from '@douyinfe/semi-ui';
+import Title from '@douyinfe/semi-ui/lib/es/typography/title';
+import { MapName } from '../../data/maplist';
+import {
+  MdOutlineTranslate,
+  MdLightMode,
+  MdDarkMode,
+  MdCastConnected,
+  MdContentCopy,
+} from 'react-icons/md';
+import ChangeMapButton from '../buttons/changeMapButton';
+import ChangeHighlightButton from '../buttons/changeHighlightButton';
+import Pikaso, { BaseShapes } from 'pikaso';
+import Announcement from '../announcement';
+import { LanguageContext } from '../../contexts/LanguageContext.ts';
+import { ThemeContext, ThemeType } from '../../contexts/ThemeContext.ts';
+import { Languages } from '../../types/interface.ts';
 
 interface HeaderContentProps {
-  changeLanguage: (lang: Languages) => void
-  changeTheme: (theme: ThemeType) => void
-  currentMap: MapName
-  mapPrepareMode: boolean
-  setPresentMap: React.Dispatch<React.SetStateAction<MapName>>
-  setPresentMapURL: React.Dispatch<React.SetStateAction<{ imgPrepareLink: string; imgBlankLink: string }>>
-  setMapPrepareMode: React.Dispatch<React.SetStateAction<boolean>>
-  editor: Pikaso<BaseShapes> | null
-  share: React.Dispatch<React.SetStateAction<void>>
+  changeLanguage: (lang: Languages) => void;
+  changeTheme: (theme: ThemeType) => void;
+  currentMap: MapName;
+  mapPrepareMode: boolean;
+  setPresentMap: React.Dispatch<React.SetStateAction<MapName>>;
+  setPresentMapURL: React.Dispatch<
+    React.SetStateAction<{ imgPrepareLink: string; imgBlankLink: string }>
+  >;
+  setMapPrepareMode: React.Dispatch<React.SetStateAction<boolean>>;
+  editor: Pikaso<BaseShapes> | null;
+  share: React.Dispatch<React.SetStateAction<void>>;
 }
 
 const HeaderContent: React.FC<HeaderContentProps> = ({
@@ -33,27 +41,44 @@ const HeaderContent: React.FC<HeaderContentProps> = ({
   setPresentMapURL,
   setMapPrepareMode,
   editor,
-  share
+  share,
 }) => {
-  const currentLanguage = useContext(LanguageContext)
-  const currentTheme = useContext(ThemeContext)
+  const currentLanguage = useContext(LanguageContext);
+  const currentTheme = useContext(ThemeContext);
 
   const switchTheme = () => {
-    changeTheme(currentTheme === "dark" ? "light" : "dark")
-  }
+    changeTheme(currentTheme === 'dark' ? 'light' : 'dark');
+  };
 
   const copyUrl = () => {
-    navigator.clipboard.writeText(location.href).then(function () {/* on clipboard success */ }, function () {/* on clipboard failed */ })
-    Toast.success('Copied')
-  }
+    navigator.clipboard.writeText(location.href).then(
+      function () {
+        /* on clipboard success */
+      },
+      function () {
+        /* on clipboard failed */
+      },
+    );
+    Toast.success('Copied');
+  };
 
   return (
     <div style={{ width: '100%' }}>
-      <Nav mode='horizontal' className='none-scrollbar minWidthAvailable' style={{ overflow: 'auto hidden', maxWidth: '100svw' }}>
+      <Nav
+        mode='horizontal'
+        className='none-scrollbar minWidthAvailable'
+        style={{ overflow: 'auto hidden', maxWidth: '100svw' }}>
         <Nav.Header>
-          <Title style={{ whiteSpace: 'nowrap' }}>{currentLanguage.title}</Title>
+          <Title style={{ whiteSpace: 'nowrap' }}>
+            {currentLanguage.title}
+          </Title>
         </Nav.Header>
-        <div style={{ flexDirection: 'column', justifyContent: 'center',marginRight: '10px'}}>
+        <div
+          style={{
+            flexDirection: 'column',
+            justifyContent: 'center',
+            marginRight: '10px',
+          }}>
           <ChangeMapButton
             editor={editor}
             currentLanguage={currentLanguage}
@@ -62,28 +87,66 @@ const HeaderContent: React.FC<HeaderContentProps> = ({
             setPresentMapURL={setPresentMapURL}
           />
         </div>
-        <div style={{ flexDirection: 'column', justifyContent: 'center',marginRight: '10px' }}>
-          <ChangeHighlightButton content={currentLanguage.mapsetting.TeamHighlight} mapPrepareMode={mapPrepareMode} setMapPrepareMode={setMapPrepareMode} />
+        <div
+          style={{
+            flexDirection: 'column',
+            justifyContent: 'center',
+            marginRight: '10px',
+          }}>
+          <ChangeHighlightButton
+            content={currentLanguage.mapsetting.TeamHighlight}
+            mapPrepareMode={mapPrepareMode}
+            setMapPrepareMode={setMapPrepareMode}
+          />
         </div>
         <div style={{}}>
           <div style={{ display: 'flex', flexDirection: 'row' }}>
-            <Button icon={<MdCastConnected style={{ fontSize: 32 }} />} size={'large'} onClick={() => { share() }} style={{margin:"2px"}}/>
-            <Button icon={<MdContentCopy style={{ fontSize: 32 }} />} size={'large'} onClick={() => { copyUrl() }} style={{margin:"2px"}} />
+            <Button
+              icon={<MdCastConnected style={{ fontSize: 32 }} />}
+              size={'large'}
+              onClick={() => {
+                share();
+              }}
+              style={{ margin: '2px' }}
+            />
+            <Button
+              icon={<MdContentCopy style={{ fontSize: 32 }} />}
+              size={'large'}
+              onClick={() => {
+                copyUrl();
+              }}
+              style={{ margin: '2px' }}
+            />
           </div>
         </div>
         <Nav.Footer>
-          <Announcement name={currentLanguage.announcement} content={currentLanguage.announcementdata} />
+          <Announcement
+            name={currentLanguage.announcement}
+            content={currentLanguage.announcementdata}
+          />
           <Button
             icon={
-              currentTheme === "light" ? (
-                <MdLightMode size='1rem' style={{ padding: '0 1rem' }} color='rgba(var(--semi-grey-9), 1)' />
+              currentTheme === 'light' ? (
+                <MdLightMode
+                  size='1rem'
+                  style={{ padding: '0 1rem' }}
+                  color='rgba(var(--semi-grey-9), 1)'
+                />
               ) : (
-                <MdDarkMode size='1rem' style={{ padding: '0 1rem' }} color='rgba(var(--semi-grey-9), 1)' />
+                <MdDarkMode
+                  size='1rem'
+                  style={{ padding: '0 1rem' }}
+                  color='rgba(var(--semi-grey-9), 1)'
+                />
               )
             }
             onClick={switchTheme}
           />
-          <MdOutlineTranslate size='1.5rem' style={{ padding: '0 1rem' }} color='rgba(var(--semi-grey-9), 1)' />
+          <MdOutlineTranslate
+            size='1.5rem'
+            style={{ padding: '0 1rem' }}
+            color='rgba(var(--semi-grey-9), 1)'
+          />
           <Select
             defaultValue={currentLanguage.language}
             onChange={(value) => changeLanguage(value as Languages)}>
@@ -96,7 +159,7 @@ const HeaderContent: React.FC<HeaderContentProps> = ({
         </Nav.Footer>
       </Nav>
     </div>
-  )
-}
+  );
+};
 
-export default HeaderContent
+export default HeaderContent;

--- a/src/components/Layouts/Popovers/ColorPopover.tsx
+++ b/src/components/Layouts/Popovers/ColorPopover.tsx
@@ -1,53 +1,77 @@
-import { ColorPicker, Popover } from '@douyinfe/semi-ui'
-import React from 'react'
-import { saveColors } from '../../../utils/canvasConstants'
-import ToolColorButton from '../Buttons/tool-color-button'
+import { ColorPicker, Popover } from '@douyinfe/semi-ui';
+import React from 'react';
+import { saveColors } from '../../../utils/canvasConstants';
+import ToolColorButton from '../Buttons/tool-color-button';
 
 interface ColorPopoverProps {
-  children: React.ReactNode
-  setPenColor: React.Dispatch<React.SetStateAction<string>>
-  colors: Array<string>
-  setColors: React.Dispatch<React.SetStateAction<Array<string>>>
-  selectedColor: number
-  setSelectedColor: React.Dispatch<React.SetStateAction<number>>
+  children: React.ReactNode;
+  setPenColor: React.Dispatch<React.SetStateAction<string>>;
+  colors: Array<string>;
+  setColors: React.Dispatch<React.SetStateAction<Array<string>>>;
+  selectedColor: number;
+  setSelectedColor: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const ColorPopover: React.FC<ColorPopoverProps> = ({ children, setPenColor, colors, setColors, selectedColor, setSelectedColor }) => {
+const ColorPopover: React.FC<ColorPopoverProps> = ({
+  children,
+  setPenColor,
+  colors,
+  setColors,
+  selectedColor,
+  setSelectedColor,
+}) => {
   const popOverContent = (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {colors.map((color, i) => (
-        <span style={selectedColor === i ? { border: '1px solid #fff' } : { border: '1px solid transparent' }} key={i}>
-          <ToolColorButton key={i} color={color} text={color} onClick={(value: string) => {
-            setPenColor(value)
-            setSelectedColor(selectedColor === i ? -1 : i)
-          }}/>
+        <span
+          style={
+            selectedColor === i
+              ? { border: '1px solid #fff' }
+              : { border: '1px solid transparent' }
+          }
+          key={i}>
+          <ToolColorButton
+            key={i}
+            color={color}
+            text={color}
+            onClick={(value: string) => {
+              setPenColor(value);
+              setSelectedColor(selectedColor === i ? -1 : i);
+            }}
+          />
         </span>
       ))}
       <ColorPicker
         onChange={(value) => {
-          setPenColor(value.hex)
-          if(selectedColor != -1) {
-            const newColors = [...colors]
-            newColors[selectedColor] = value.hex
-            setColors(newColors)
-            requestAnimationFrame(()=>{saveColors(colors)})
+          setPenColor(value.hex);
+          if (selectedColor != -1) {
+            const newColors = [...colors];
+            newColors[selectedColor] = value.hex;
+            setColors(newColors);
+            requestAnimationFrame(() => {
+              saveColors(colors);
+            });
           }
         }}
         alpha={false}
         usePopover={true}
         popoverProps={{ position: 'left' }}>
         <div>
-          <ToolColorButton text={'custom'} color='linear-gradient(70deg, red, blue)' onClick={() => 0} />
+          <ToolColorButton
+            text={'custom'}
+            color='linear-gradient(70deg, red, blue)'
+            onClick={() => 0}
+          />
         </div>
       </ColorPicker>
     </div>
-  )
+  );
 
   return (
     <Popover content={popOverContent} position='left'>
       <div>{children}</div>
     </Popover>
-  )
-}
+  );
+};
 
-export default ColorPopover
+export default ColorPopover;

--- a/src/components/Layouts/Sider/SiderContent.tsx
+++ b/src/components/Layouts/Sider/SiderContent.tsx
@@ -1,54 +1,74 @@
-import React, { useContext } from 'react'
-import { Divider, TabPane, Tabs } from '@douyinfe/semi-ui'
-import { GiBroadsword, GiShield, GiStunGrenade } from 'react-icons/gi'
-import { characterRegistry } from '../../../data/characters/characterRegistry.ts'
-import { OtherRow, GrenadeRow, PUSRow, TheScissorsRow, UrbinoRow } from './SiderContentRow.tsx'
-import { LanguageContext } from '../../../contexts/LanguageContext.ts'
+import React, { useContext } from 'react';
+import { Divider, TabPane, Tabs } from '@douyinfe/semi-ui';
+import { GiBroadsword, GiShield, GiStunGrenade } from 'react-icons/gi';
+import { characterRegistry } from '../../../data/characters/characterRegistry.ts';
+import {
+  OtherRow,
+  GrenadeRow,
+  PUSRow,
+  TheScissorsRow,
+  UrbinoRow,
+} from './SiderContentRow.tsx';
+import { LanguageContext } from '../../../contexts/LanguageContext.ts';
 
 interface SiderContentProps {
   characterRegistry: characterRegistry | null;
   collaps?: boolean;
 }
 
-const SiderContent: React.FC<SiderContentProps> = ({ characterRegistry, collaps }) => {
-  const currentLanguage = useContext(LanguageContext)
+const SiderContent: React.FC<SiderContentProps> = ({
+  characterRegistry,
+  collaps,
+}) => {
+  const currentLanguage = useContext(LanguageContext);
 
-  if (characterRegistry === null)
-    return <div></div>;
+  if (characterRegistry === null) return <div></div>;
 
   return (
-    <div style={{ height: "100%" }}>
-      <div style={{ overflowX: 'hidden', position: 'relative', height: "100%", maxWidth: collaps ? "0px" : '320px', transition: "max-width 0.1s linear" }}>
+    <div style={{ height: '100%' }}>
+      <div
+        style={{
+          overflowX: 'hidden',
+          position: 'relative',
+          height: '100%',
+          maxWidth: collaps ? '0px' : '320px',
+          transition: 'max-width 0.1s linear',
+        }}>
         <div style={{ width: '320px' }}>
-          <Tabs style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <Tabs
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}>
             <TabPane
               tab={
                 <span>
-                  <GiBroadsword style={{ margin: "0 auto" }} />
+                  <GiBroadsword style={{ margin: '0 auto' }} />
                   {currentLanguage.sidebar.attact}
                 </span>
               }
               itemKey='attack'>
               <TheScissorsRow characterRegistry={characterRegistry} />
               <Divider dashed margin={'1rem'} />
-              <UrbinoRow characterRegistry={characterRegistry} side="attack" />
+              <UrbinoRow characterRegistry={characterRegistry} side='attack' />
             </TabPane>
             <TabPane
               tab={
                 <span>
-                  <GiShield style={{ margin: "0 auto" }} />
+                  <GiShield style={{ margin: '0 auto' }} />
                   {currentLanguage.sidebar.defense}
                 </span>
               }
               itemKey='defense'>
               <PUSRow characterRegistry={characterRegistry} />
               <Divider dashed margin={'1rem'} />
-              <UrbinoRow characterRegistry={characterRegistry} side="defense" />
+              <UrbinoRow characterRegistry={characterRegistry} side='defense' />
             </TabPane>
             <TabPane
               tab={
                 <span>
-                  <GiStunGrenade style={{ margin: "0 auto" }} />
+                  <GiStunGrenade style={{ margin: '0 auto' }} />
                   {currentLanguage.sidebar.other}
                 </span>
               }
@@ -62,7 +82,7 @@ const SiderContent: React.FC<SiderContentProps> = ({ characterRegistry, collaps 
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default SiderContent
+export default SiderContent;

--- a/src/components/Layouts/Sider/SiderContentRow.tsx
+++ b/src/components/Layouts/Sider/SiderContentRow.tsx
@@ -1,67 +1,113 @@
-import { PUS, TheScissors, Urbino } from '../../../data/characters/factions.ts'
-import { CharacterSiderItem, GrenadeSiderItem, OtherSiderItem } from './SiderItem.tsx'
-import React from 'react'
-import { Col, Row } from '@douyinfe/semi-ui'
-import { characterData, characterRegistry } from '../../../data/characters/characterRegistry.ts'
-import { grenadeData, otherData } from '../../../data/grenades.ts'
+import { PUS, TheScissors, Urbino } from '../../../data/characters/factions.ts';
+import {
+  CharacterSiderItem,
+  GrenadeSiderItem,
+  OtherSiderItem,
+} from './SiderItem.tsx';
+import React from 'react';
+import { Col, Row } from '@douyinfe/semi-ui';
+import {
+  characterData,
+  characterRegistry,
+} from '../../../data/characters/characterRegistry.ts';
+import { grenadeData, otherData } from '../../../data/grenades.ts';
 
 interface SiderContentRowProps {
-  data: characterData[]
-  side: "attack" | "defense"
+  data: characterData[];
+  side: 'attack' | 'defense';
 }
 
 const SiderContentRow: React.FC<SiderContentRowProps> = ({ data, side }) => {
   return (
-    <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+    <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
       {data.map((itemData, i) => (
-        <Col key={i} span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
+        <Col
+          key={i}
+          span={6}
+          style={{
+            display: 'flex',
+            placeItems: 'center',
+            placeContent: 'center',
+          }}>
           <CharacterSiderItem data={itemData} side={side} />
         </Col>
       ))}
     </Row>
-  )
-}
+  );
+};
 
 interface RowProps {
   characterRegistry: characterRegistry;
 }
 
 interface ExtendedRowProps extends RowProps {
-  side: "attack" | "defense";
+  side: 'attack' | 'defense';
 }
 
 export const TheScissorsRow: React.FC<RowProps> = ({ characterRegistry }) => {
-  return <SiderContentRow data={Object.values(TheScissors).map((k: string) => characterRegistry[k])} side="attack" />
-}
+  return (
+    <SiderContentRow
+      data={Object.values(TheScissors).map((k: string) => characterRegistry[k])}
+      side='attack'
+    />
+  );
+};
 
-export const UrbinoRow: React.FC<ExtendedRowProps> = ({ characterRegistry, side }) => {
-  return <SiderContentRow data={Object.values(Urbino).map((k: string) => characterRegistry[k])} side={side} />
-}
+export const UrbinoRow: React.FC<ExtendedRowProps> = ({
+  characterRegistry,
+  side,
+}) => {
+  return (
+    <SiderContentRow
+      data={Object.values(Urbino).map((k: string) => characterRegistry[k])}
+      side={side}
+    />
+  );
+};
 
 export const PUSRow: React.FC<RowProps> = ({ characterRegistry }) => {
-  return <SiderContentRow data={Object.values(PUS).map((k: string) => characterRegistry[k])} side="defense" />
-}
+  return (
+    <SiderContentRow
+      data={Object.values(PUS).map((k: string) => characterRegistry[k])}
+      side='defense'
+    />
+  );
+};
 
 export const GrenadeRow: React.FC = () => {
   return (
-    <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+    <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
       {grenadeData.map((itemData, i) => (
-        <Col key={i} span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
+        <Col
+          key={i}
+          span={6}
+          style={{
+            display: 'flex',
+            placeItems: 'center',
+            placeContent: 'center',
+          }}>
           <GrenadeSiderItem data={itemData} />
         </Col>
       ))}
     </Row>
-  )
-}
+  );
+};
 
 export const OtherRow: React.FC = () => {
   return (
-    <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+    <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
       {otherData.map((itemData, i) => (
-        <Col key={i} span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
+        <Col
+          key={i}
+          span={6}
+          style={{
+            display: 'flex',
+            placeItems: 'center',
+            placeContent: 'center',
+          }}>
           <OtherSiderItem data={itemData} />
         </Col>
       ))}
     </Row>
-  )
-}
+  );
+};

--- a/src/components/Layouts/Sider/SiderItem.tsx
+++ b/src/components/Layouts/Sider/SiderItem.tsx
@@ -1,14 +1,21 @@
-import React, { useContext } from 'react'
-import { Avatar, Card, Popover, TabPane, Tabs, Tooltip } from '@douyinfe/semi-ui'
-import { characterData } from '../../../data/characters/characterRegistry.ts'
-import { grenadeData, otherData } from '../../../data/grenades.ts'
-import { LanguageContext } from '../../../contexts/LanguageContext.ts'
-import { GrDrag } from "react-icons/gr";
-import { setDragValue } from '../../../data/dragAndDrop.ts'
+import React, { useContext } from 'react';
+import {
+  Avatar,
+  Card,
+  Popover,
+  TabPane,
+  Tabs,
+  Tooltip,
+} from '@douyinfe/semi-ui';
+import { characterData } from '../../../data/characters/characterRegistry.ts';
+import { grenadeData, otherData } from '../../../data/grenades.ts';
+import { LanguageContext } from '../../../contexts/LanguageContext.ts';
+import { GrDrag } from 'react-icons/gr';
+import { setDragValue } from '../../../data/dragAndDrop.ts';
 
 interface CharacterSiderItemProps {
-  data: characterData
-  side: "attack" | "defense"
+  data: characterData;
+  side: 'attack' | 'defense';
 }
 
 const hoverStyle = {
@@ -17,125 +24,333 @@ const hoverStyle = {
   width: '100%',
   display: 'flex',
   alianItems: 'center',
-  justifyContent: 'center'
+  justifyContent: 'center',
 };
-const HoverMask = () => <div style={hoverStyle}><GrDrag style={{ margin: "auto", color: "rgba(var(--semi-light-blue-5), 1)" }} /></div>;
+const HoverMask = () => (
+  <div style={hoverStyle}>
+    <GrDrag
+      style={{ margin: 'auto', color: 'rgba(var(--semi-light-blue-5), 1)' }}
+    />
+  </div>
+);
 
-export const CharacterSiderItem: React.FC<CharacterSiderItemProps> = ({ data, side }) => {
-  const currentLanguage = useContext(LanguageContext)
+export const CharacterSiderItem: React.FC<CharacterSiderItemProps> = ({
+  data,
+  side,
+}) => {
+  const currentLanguage = useContext(LanguageContext);
 
   const sideData = data[side]!;
 
   const onDragStart = () => {
-    setDragValue({ type: 'imageLink', value: sideData.canvasImage })
-  }
+    setDragValue({ type: 'imageLink', value: sideData.canvasImage });
+  };
 
   const onTouchStart = () => {
-    setDragValue({ type: 'imageLink', value: sideData.canvasImage })
-  }
+    setDragValue({ type: 'imageLink', value: sideData.canvasImage });
+  };
 
-  const onDragStartImage = (_e: React.DragEvent<HTMLSpanElement>, imageLink: string) => {
-    setDragValue({ type: 'imageLink', value: imageLink })
-  }
+  const onDragStartImage = (
+    _e: React.DragEvent<HTMLSpanElement>,
+    imageLink: string,
+  ) => {
+    setDragValue({ type: 'imageLink', value: imageLink });
+  };
 
-  const onTouchStartImage = (_e: React.TouchEvent<HTMLSpanElement>, imageLink: string) => {
-    setDragValue({ type: 'imageLink', value: imageLink })
-  }
+  const onTouchStartImage = (
+    _e: React.TouchEvent<HTMLSpanElement>,
+    imageLink: string,
+  ) => {
+    setDragValue({ type: 'imageLink', value: imageLink });
+  };
 
   return (
     <Popover
-      position='rightTop' trigger='click'
-      content={<Card style={{ width: '620px', height: "100%", margin: "0 auto", overflow: "hidden" }}>
-        <div style={{ display: "flex", height: "100%" }}>
-          <div style={{ height: "360px", width: "200px",display:"flex relative" }}>
-            <img draggable="false" src={sideData.bodyImage} style={{ height: "420px", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-7))" }} />
-            <div style={{ position: "absolute", left: "40px", bottom: "110px", height: "25px", display: "flex", alignContent: "center", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-7))" }}>
-              {currentLanguage.characterInfo[data.id].Type == currentLanguage.characterTypes.Duellist ? <img draggable="false" src="https://s2.loli.net/2024/10/27/c7QDINMXFyuav6b.png" style={{ filter: "invert(100%)", height: "25px" }} /> : <></>}
-              {currentLanguage.characterInfo[data.id].Type == currentLanguage.characterTypes.Support ? <img draggable="false" src="https://s2.loli.net/2024/11/11/seAIvkZLtWGrlwd.png" style={{ filter: "invert(100%)", height: "25px" }} /> : <></>}
-              {currentLanguage.characterInfo[data.id].Type == currentLanguage.characterTypes.Controller ? <img draggable="false" src="https://s2.loli.net/2024/11/11/oLVSxJBTrynRv7F.png" style={{ filter: "invert(100%)", height: "25px" }} /> : <></>}
-              {currentLanguage.characterInfo[data.id].Type == currentLanguage.characterTypes.Sentinel ? <img draggable="false" src="https://s2.loli.net/2024/11/11/jEuQg1bt2veBrTP.png" style={{ filter: "invert(100%)", height: "25px" }} /> : <></>}
-              {currentLanguage.characterInfo[data.id].Type == currentLanguage.characterTypes.Initiator ? <img draggable="false" src="https://s2.loli.net/2024/11/11/OfZRtlo2ICDKNHG.png" style={{ filter: "invert(100%)", height: "25px" }} /> : <></>}
-              <span style={{ fontSize: "18px", margin: "1.5px", marginLeft: "5px", color: "white" }}><strong>{currentLanguage.characterInfo[data.id].Type}</strong></span>
+      position='rightTop'
+      trigger='click'
+      content={
+        <Card
+          style={{
+            width: '620px',
+            height: '100%',
+            margin: '0 auto',
+            overflow: 'hidden',
+          }}>
+          <div style={{ display: 'flex', height: '100%' }}>
+            <div
+              style={{
+                height: '360px',
+                width: '200px',
+                display: 'flex relative',
+              }}>
+              <img
+                draggable='false'
+                src={sideData.bodyImage}
+                style={{
+                  height: '420px',
+                  filter: 'drop-shadow(0 0 5px rgba(var(--semi-grey-7))',
+                }}
+              />
+              <div
+                style={{
+                  position: 'absolute',
+                  left: '40px',
+                  bottom: '110px',
+                  height: '25px',
+                  display: 'flex',
+                  alignContent: 'center',
+                  filter: 'drop-shadow(0 0 5px rgba(var(--semi-grey-7))',
+                }}>
+                {currentLanguage.characterInfo[data.id].Type ==
+                currentLanguage.characterTypes.Duellist ? (
+                  <img
+                    draggable='false'
+                    src='https://s2.loli.net/2024/10/27/c7QDINMXFyuav6b.png'
+                    style={{ filter: 'invert(100%)', height: '25px' }}
+                  />
+                ) : (
+                  <></>
+                )}
+                {currentLanguage.characterInfo[data.id].Type ==
+                currentLanguage.characterTypes.Support ? (
+                  <img
+                    draggable='false'
+                    src='https://s2.loli.net/2024/11/11/seAIvkZLtWGrlwd.png'
+                    style={{ filter: 'invert(100%)', height: '25px' }}
+                  />
+                ) : (
+                  <></>
+                )}
+                {currentLanguage.characterInfo[data.id].Type ==
+                currentLanguage.characterTypes.Controller ? (
+                  <img
+                    draggable='false'
+                    src='https://s2.loli.net/2024/11/11/oLVSxJBTrynRv7F.png'
+                    style={{ filter: 'invert(100%)', height: '25px' }}
+                  />
+                ) : (
+                  <></>
+                )}
+                {currentLanguage.characterInfo[data.id].Type ==
+                currentLanguage.characterTypes.Sentinel ? (
+                  <img
+                    draggable='false'
+                    src='https://s2.loli.net/2024/11/11/jEuQg1bt2veBrTP.png'
+                    style={{ filter: 'invert(100%)', height: '25px' }}
+                  />
+                ) : (
+                  <></>
+                )}
+                {currentLanguage.characterInfo[data.id].Type ==
+                currentLanguage.characterTypes.Initiator ? (
+                  <img
+                    draggable='false'
+                    src='https://s2.loli.net/2024/11/11/OfZRtlo2ICDKNHG.png'
+                    style={{ filter: 'invert(100%)', height: '25px' }}
+                  />
+                ) : (
+                  <></>
+                )}
+                <span
+                  style={{
+                    fontSize: '18px',
+                    margin: '1.5px',
+                    marginLeft: '5px',
+                    color: 'white',
+                  }}>
+                  <strong>{currentLanguage.characterInfo[data.id].Type}</strong>
+                </span>
+              </div>
+              <div
+                style={{
+                  position: 'absolute',
+                  left: '35px',
+                  bottom: '140px',
+                  height: '25px',
+                  display: 'flex',
+                  alignContent: 'center',
+                  filter: 'drop-shadow(0 0 5px rgba(var(--semi-grey-7))',
+                }}>
+                <span
+                  style={{
+                    fontSize: '18px',
+                    margin: '1.5px',
+                    marginLeft: '5px',
+                    color: 'white',
+                  }}>
+                  <strong>{currentLanguage.characterInfo[data.id].Name}</strong>
+                </span>
+              </div>
             </div>
-            <div style={{ position: "absolute", left: "35px", bottom: "140px", height: "25px", display: "flex", alignContent: "center", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-7))" }}>
-              <span style={{ fontSize: "18px", margin: "1.5px", marginLeft: "5px", color: "white" }}><strong>{currentLanguage.characterInfo[data.id].Name}</strong></span>
+            <div
+              style={{
+                width: '100%',
+                fontSize: '14px',
+                marginRight: '15px',
+                marginTop: '3px',
+              }}>
+              <Tabs type='button'>
+                <TabPane
+                  tab={
+                    <span
+                      draggable
+                      onDragStart={(e) => {
+                        onDragStartImage(e, sideData.skills.active.skillIcon);
+                      }}
+                      onTouchStart={(e) => {
+                        onTouchStartImage(e, sideData.skills.active.skillIcon);
+                      }}>
+                      <Avatar
+                        src={sideData.skills.active.skillIcon}
+                        style={{
+                          margin: '0 auto',
+                          height: '40px',
+                          width: '40px',
+                        }}
+                        hoverMask={<HoverMask />}
+                      />
+                    </span>
+                  }
+                  itemKey='1'>
+                  <div style={{ fontWeight: 'bold' }}>
+                    {currentLanguage.characterInfo[data.id].skillActiveName}
+                  </div>
+                  <div
+                    style={{
+                      margin: '2px',
+                      maxHeight: '100%',
+                      overflowY: 'scroll',
+                      filter: 'drop-shadow(0 0 5px rgba(var(--semi-grey-2))',
+                    }}
+                    className='none-scrollbar'>
+                    {
+                      currentLanguage.characterInfo[data.id]
+                        .skillActiveDescription
+                    }
+                  </div>
+                </TabPane>
+                <TabPane
+                  tab={
+                    <span
+                      draggable
+                      onDragStart={(e) => {
+                        onDragStartImage(e, sideData.skills.passive.skillIcon);
+                      }}
+                      onTouchStart={(e) => {
+                        onTouchStartImage(e, sideData.skills.passive.skillIcon);
+                      }}>
+                      <Avatar
+                        src={sideData.skills.passive.skillIcon}
+                        style={{
+                          margin: '0 auto',
+                          height: '40px',
+                          width: '40px',
+                        }}
+                        hoverMask={<HoverMask />}
+                      />
+                    </span>
+                  }
+                  itemKey='2'>
+                  <div style={{ fontWeight: 'bold' }}>
+                    {currentLanguage.characterInfo[data.id].skillPassiveName}
+                  </div>
+                  <div
+                    style={{
+                      margin: '2px',
+                      maxHeight: '100%',
+                      overflowY: 'scroll',
+                      filter: 'drop-shadow(0 0 5px rgba(var(--semi-grey-2))',
+                    }}
+                    className='none-scrollbar'>
+                    {
+                      currentLanguage.characterInfo[data.id]
+                        .skillPassiveDescription
+                    }
+                  </div>
+                </TabPane>
+                <TabPane
+                  tab={
+                    <span
+                      draggable
+                      onDragStart={(e) => {
+                        onDragStartImage(e, sideData.skills.ultimate.skillIcon);
+                      }}
+                      onTouchStart={(e) => {
+                        onTouchStartImage(
+                          e,
+                          sideData.skills.ultimate.skillIcon,
+                        );
+                      }}>
+                      <Avatar
+                        src={sideData.skills.ultimate.skillIcon}
+                        style={{
+                          margin: '0 auto',
+                          height: '40px',
+                          width: '40px',
+                        }}
+                        hoverMask={<HoverMask />}
+                      />
+                    </span>
+                  }
+                  itemKey='3'>
+                  <div style={{ fontWeight: 'bold' }}>
+                    {currentLanguage.characterInfo[data.id].skillUltimateName}
+                  </div>
+                  <div
+                    style={{
+                      margin: '2px',
+                      maxHeight: '100%',
+                      overflowY: 'scroll',
+                      filter: 'drop-shadow(0 0 5px rgba(var(--semi-grey-2))',
+                    }}
+                    className='none-scrollbar'>
+                    {
+                      currentLanguage.characterInfo[data.id]
+                        .skillUltimateDescription
+                    }
+                  </div>
+                </TabPane>
+                <TabPane
+                  tab={
+                    <span
+                      draggable
+                      onDragStart={(e) => {
+                        onDragStartImage(e, sideData.skills.sub.skillIcon);
+                      }}
+                      onTouchStart={(e) => {
+                        onTouchStartImage(e, sideData.skills.sub.skillIcon);
+                      }}>
+                      <Avatar
+                        src={sideData.skills.sub.skillIcon}
+                        style={{
+                          margin: '0 auto',
+                          height: '40px',
+                          width: '40px',
+                        }}
+                        hoverMask={<HoverMask />}
+                      />
+                    </span>
+                  }
+                  itemKey='4'>
+                  <div style={{ fontWeight: 'bold' }}>
+                    {currentLanguage.characterInfo[data.id].subName}
+                  </div>
+                  <div
+                    style={{
+                      margin: '2px',
+                      maxHeight: '100%',
+                      overflowY: 'scroll',
+                      filter: 'drop-shadow(0 0 5px rgba(var(--semi-grey-2))',
+                    }}
+                    className='none-scrollbar'>
+                    {currentLanguage.characterInfo[data.id].subDescription}
+                  </div>
+                </TabPane>
+              </Tabs>
             </div>
           </div>
-          <div style={{ width: "100%", fontSize: "14px", marginRight: "15px", marginTop: "3px" }}>
-            <Tabs type="button">
-              <TabPane
-                tab={
-                  <span draggable onDragStart={(e) => { onDragStartImage(e, sideData.skills.active.skillIcon) }} onTouchStart={(e) => { onTouchStartImage(e, sideData.skills.active.skillIcon) }}>
-                    <Avatar
-                      src={sideData.skills.active.skillIcon}
-                      style={{ margin: '0 auto', height: "40px", width: "40px" }}
-                      hoverMask={<HoverMask />}
-                    />
-                  </span>
-                }
-                itemKey="1"
-              >
-                <div style={{ fontWeight: "bold" }}>{currentLanguage.characterInfo[data.id].skillActiveName}</div>
-                <div style={{ margin: "2px", maxHeight: "100%", overflowY: "scroll", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-2))" }} className='none-scrollbar'>
-                  {currentLanguage.characterInfo[data.id].skillActiveDescription}
-                </div>
-              </TabPane>
-              <TabPane
-                tab={
-                  <span draggable onDragStart={(e) => { onDragStartImage(e, sideData.skills.passive.skillIcon) }} onTouchStart={(e) => { onTouchStartImage(e, sideData.skills.passive.skillIcon) }}>
-                    <Avatar
-                      src={sideData.skills.passive.skillIcon}
-                      style={{ margin: '0 auto', height: "40px", width: "40px" }}
-                      hoverMask={<HoverMask />}
-                    />
-                  </span>
-                }
-                itemKey="2"
-              >
-                <div style={{ fontWeight: "bold" }}>{currentLanguage.characterInfo[data.id].skillPassiveName}</div>
-                <div style={{ margin: "2px", maxHeight: "100%", overflowY: "scroll", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-2))" }} className='none-scrollbar'>
-                  {currentLanguage.characterInfo[data.id].skillPassiveDescription}
-                </div>
-              </TabPane>
-              <TabPane
-                tab={
-                  <span draggable onDragStart={(e) => { onDragStartImage(e, sideData.skills.ultimate.skillIcon) }} onTouchStart={(e) => { onTouchStartImage(e, sideData.skills.ultimate.skillIcon) }}>
-                    <Avatar
-                      src={sideData.skills.ultimate.skillIcon}
-                      style={{ margin: '0 auto', height: "40px", width: "40px" }}
-                      hoverMask={<HoverMask />}
-                    />
-                  </span>
-                }
-                itemKey="3"
-              >
-                <div style={{ fontWeight: "bold" }}>{currentLanguage.characterInfo[data.id].skillUltimateName}</div>
-                <div style={{ margin: "2px", maxHeight: "100%", overflowY: "scroll", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-2))" }} className='none-scrollbar'>
-                  {currentLanguage.characterInfo[data.id].skillUltimateDescription}
-                </div>
-              </TabPane>
-              <TabPane
-                tab={
-                  <span draggable onDragStart={(e) => { onDragStartImage(e, sideData.skills.sub.skillIcon) }} onTouchStart={(e) => { onTouchStartImage(e, sideData.skills.sub.skillIcon) }}>
-                    <Avatar
-                      src={sideData.skills.sub.skillIcon}
-                      style={{ margin: '0 auto', height: "40px", width: "40px" }}
-                      hoverMask={<HoverMask />}
-                    />
-                  </span>
-                }
-                itemKey="4"
-              >
-                <div style={{ fontWeight: "bold" }}>{currentLanguage.characterInfo[data.id].subName}</div>
-                <div style={{ margin: "2px", maxHeight: "100%", overflowY: "scroll", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-2))" }} className='none-scrollbar'>
-                  {currentLanguage.characterInfo[data.id].subDescription}
-                </div>
-              </TabPane>
-            </Tabs>
-          </div>
-        </div>
-      </Card>}
-    >
+        </Card>
+      }>
       <span draggable onDragStart={onDragStart} onTouchStart={onTouchStart}>
         <Avatar
           src={sideData.canvasImage}
@@ -144,62 +359,101 @@ export const CharacterSiderItem: React.FC<CharacterSiderItemProps> = ({ data, si
         />
       </span>
     </Popover>
-  )
-}
+  );
+};
 
 interface GrenadeSiderItemProps {
-  data: grenadeData
+  data: grenadeData;
 }
 
 export const GrenadeSiderItem: React.FC<GrenadeSiderItemProps> = ({ data }) => {
-  const currentLanguage = useContext(LanguageContext)
+  const currentLanguage = useContext(LanguageContext);
 
-  const onDragStart = (_e: React.DragEvent<HTMLSpanElement>, data: grenadeData) => {
-    setDragValue({ type: 'imageLink', value: data.imageLink })
-  }
+  const onDragStart = (
+    _e: React.DragEvent<HTMLSpanElement>,
+    data: grenadeData,
+  ) => {
+    setDragValue({ type: 'imageLink', value: data.imageLink });
+  };
 
-  const onTouchStart = (_e: React.TouchEvent<HTMLSpanElement>, data: grenadeData) => {
-    setDragValue({ type: 'imageLink', value: data.imageLink })
-  }
+  const onTouchStart = (
+    _e: React.TouchEvent<HTMLSpanElement>,
+    data: grenadeData,
+  ) => {
+    setDragValue({ type: 'imageLink', value: data.imageLink });
+  };
 
   return (
-    <Tooltip position='topLeft' content={currentLanguage.grenades[data.grenade]}>
-      <span draggable onDragStart={(e) => { onDragStart(e, data) }} onTouchStart={(e) => { onTouchStart(e, data) }}>
+    <Tooltip
+      position='topLeft'
+      content={currentLanguage.grenades[data.grenade]}>
+      <span
+        draggable
+        onDragStart={(e) => {
+          onDragStart(e, data);
+        }}
+        onTouchStart={(e) => {
+          onTouchStart(e, data);
+        }}>
         <Avatar
           src={data.imageLink}
-          style={{ margin: '0.25rem', backgroundColor: "grey", height: "48px", width: "48px" }}
+          style={{
+            margin: '0.25rem',
+            backgroundColor: 'grey',
+            height: '48px',
+            width: '48px',
+          }}
           hoverMask={<HoverMask />}
         />
       </span>
     </Tooltip>
-  )
-}
+  );
+};
 
 interface OtherSiderItemProps {
-  data: otherData
+  data: otherData;
 }
 
 export const OtherSiderItem: React.FC<OtherSiderItemProps> = ({ data }) => {
-  const currentLanguage = useContext(LanguageContext)
+  const currentLanguage = useContext(LanguageContext);
 
-  const onDragStart = (_e: React.DragEvent<HTMLSpanElement>, data: otherData) => {
-    setDragValue({ type: 'imageLink', value: data.imageLink })
-  }
+  const onDragStart = (
+    _e: React.DragEvent<HTMLSpanElement>,
+    data: otherData,
+  ) => {
+    setDragValue({ type: 'imageLink', value: data.imageLink });
+  };
 
-  const onTouchStart = (_e: React.TouchEvent<HTMLSpanElement>, data: otherData) => {
-    setDragValue({ type: 'imageLink', value: data.imageLink })
-  }
+  const onTouchStart = (
+    _e: React.TouchEvent<HTMLSpanElement>,
+    data: otherData,
+  ) => {
+    setDragValue({ type: 'imageLink', value: data.imageLink });
+  };
 
   return (
     <Tooltip position='topLeft' content={currentLanguage.others[data.other]}>
-      <span draggable onDragStart={(e) => { onDragStart(e, data) }} onTouchStart={(e) => { onTouchStart(e, data) }}>
+      <span
+        draggable
+        onDragStart={(e) => {
+          onDragStart(e, data);
+        }}
+        onTouchStart={(e) => {
+          onTouchStart(e, data);
+        }}>
         <Avatar
           src={data.imageLink}
           shape='square'
-          style={{ margin: '0.25rem',padding:"0.5rem", backgroundColor: "grey", height: "30px", width: "30px" }}
+          style={{
+            margin: '0.25rem',
+            padding: '0.5rem',
+            backgroundColor: 'grey',
+            height: '30px',
+            width: '30px',
+          }}
           hoverMask={<HoverMask />}
         />
       </span>
     </Tooltip>
-  )
-}
+  );
+};

--- a/src/components/Layouts/SiderContent.tsx
+++ b/src/components/Layouts/SiderContent.tsx
@@ -1,218 +1,411 @@
-import React from 'react'
-import { Avatar, Divider, TabPane, Tabs, Col, Row, Tooltip, Card, Popover, Descriptions } from '@douyinfe/semi-ui'
-import { GiBroadsword, GiShield, GiStunGrenade } from 'react-icons/gi'
-import { PUS, TheScissors, Urbino } from '../../data/characters/factions'
-import { characterData, characterRegistry } from '../../data/characters/characterRegistry'
-import { grenadeData } from '../../data/grenades'
-import { I18nData } from '../../types/interface'
+import React from 'react';
+import {
+  Avatar,
+  Divider,
+  TabPane,
+  Tabs,
+  Col,
+  Row,
+  Tooltip,
+  Card,
+  Popover,
+  Descriptions,
+} from '@douyinfe/semi-ui';
+import { GiBroadsword, GiShield, GiStunGrenade } from 'react-icons/gi';
+import { PUS, TheScissors, Urbino } from '../../data/characters/factions';
+import {
+  characterData,
+  characterRegistry,
+} from '../../data/characters/characterRegistry';
+import { grenadeData } from '../../data/grenades';
+import { I18nData } from '../../types/interface';
 
 interface SiderContentProps {
-  currentLanguage: I18nData
+  currentLanguage: I18nData;
   characterRegistry: characterRegistry | null;
-  setSelectedCharacter: React.Dispatch<React.SetStateAction<characterData | null>>
-  setSiderSide: React.Dispatch<React.SetStateAction<'attack' | 'defense'>>
+  setSelectedCharacter: React.Dispatch<
+    React.SetStateAction<characterData | null>
+  >;
+  setSiderSide: React.Dispatch<React.SetStateAction<'attack' | 'defense'>>;
 }
 
-const SiderContent: React.FC<SiderContentProps> = ({ currentLanguage: currentLanguageMode, setSelectedCharacter, setSiderSide, characterRegistry }) => {
-  const onDragStart = (event: React.DragEvent<HTMLSpanElement>, character: string, side: 'attack' | 'defense') => {
-    event.dataTransfer.setData('character', character)
-    event.dataTransfer.setData('side', side)
+const SiderContent: React.FC<SiderContentProps> = ({
+  currentLanguage: currentLanguageMode,
+  setSelectedCharacter,
+  setSiderSide,
+  characterRegistry,
+}) => {
+  const onDragStart = (
+    event: React.DragEvent<HTMLSpanElement>,
+    character: string,
+    side: 'attack' | 'defense',
+  ) => {
+    event.dataTransfer.setData('character', character);
+    event.dataTransfer.setData('side', side);
 
     if (characterRegistry) {
-      const char = characterRegistry[character]
-      setSelectedCharacter(char)
+      const char = characterRegistry[character];
+      setSelectedCharacter(char);
     }
-  }
+  };
 
   return (
     <div>
-      <Tabs onChange={(activeKey) => { setSiderSide(activeKey as 'attack' | 'defense'); setSelectedCharacter(null) }} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <Tabs
+        onChange={(activeKey) => {
+          setSiderSide(activeKey as 'attack' | 'defense');
+          setSelectedCharacter(null);
+        }}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}>
         <TabPane
           tab={
             <span>
-              <GiBroadsword style={{ margin: "0 auto" }} />
+              <GiBroadsword style={{ margin: '0 auto' }} />
               {currentLanguageMode.sidebar.attact}
             </span>
           }
           itemKey='attack'>
-          <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+          <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
             {Object.keys(TheScissors).map((key: unknown) => {
               return (
-                <Col span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
+                <Col
+                  span={6}
+                  style={{
+                    display: 'flex',
+                    placeItems: 'center',
+                    placeContent: 'center',
+                  }}>
                   <Popover
                     position='rightTop'
-                    content={<Card style={{ width: '500px', height: "100%", margin: "0 auto", overflow: "hidden" }}>
-                      <div style={{ display: "flex", height: "100%" }}>
-                        <div style={{ height: "360px", width: "200px", margin: "0 auto", display: "relative" }}>
-                          <img draggable="false" src="https://s2.loli.net/2024/10/26/iD1g23pnC9d6hVM.png" style={{ height: "360px", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-7))" }} />
-                          <div style={{ position: "absolute", left: "40px", bottom: "60px", height: "25px", display: "flex", alignContent: "center", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-7))" }}>
-                            <img draggable="false" src="https://s2.loli.net/2024/10/27/c7QDINMXFyuav6b.png" style={{ filter: "invert(100%)", height: "25px" }} />
-                            <span style={{ fontSize: "18px", margin: "1.5px", marginLeft: "5px", color: "white" }}><strong>决斗</strong></span>
-                          </div>
-                          <div style={{ position: "absolute", left: "40px", bottom: "80px", height: "25px", display: "flex", alignContent: "center", filter: "drop-shadow(0 0 5px rgba(var(--semi-grey-7))" }}>
-                            <span style={{ fontSize: "18px", margin: "1.5px", marginLeft: "5px", color: "white" }}><strong>明</strong></span>
-                          </div>
-                        </div>
-                        <div style={{ width: "100%", fontSize: "10px", marginRight: "15px", marginTop: "3px" }}>
-                          <Tabs type="button">
-                            <TabPane
-                              tab={
-                                <Avatar
-                                  src={characterRegistry!["Ming"].attack?.skills.active.skillIcon}
-                                  style={{ margin: '0 auto', height: "40px", width: "40px" }}
-                                />
-                              }
-                              itemKey="1"
-                            >
-                              <div className='none-scrollbar' style={{ margin: "2px", height: "70px", overflowY: "scroll" }}>
-                                明发射一个电球，其达到最大距离、碰到敌方超弦体时会自动引爆，也可通过手动再次按下技能键后主动引爆。电球会破坏范围内所有敌方单位（包含召唤物）的护甲并造成减速。明进入电场将提升移动速度。
-                              </div>
-                              <Descriptions
-                                className='none-scrollbar'
-                                style={{ marginTop: "10px", maxHeight: "190px", overflowY: "scroll" }}
-                                align='left'
-                                data={[
-                                  { key: "冷却", value: "25秒" },
-                                  { key: "最远距离", value: "60米" },
-                                  { key: "最短起爆", value: "8米" },
-                                  { key: "作用范围", value: "半径5米" },
-                                  { key: "移速提升", value: "20%" },
-                                  { key: "移速提升", value: "20%" },
-                                  { key: "移速提升", value: "20%" },
-                                  { key: "移速提升", value: "20%" },
-                                ]}
+                    content={
+                      <Card
+                        style={{
+                          width: '500px',
+                          height: '100%',
+                          margin: '0 auto',
+                          overflow: 'hidden',
+                        }}>
+                        <div style={{ display: 'flex', height: '100%' }}>
+                          <div
+                            style={{
+                              height: '360px',
+                              width: '200px',
+                              margin: '0 auto',
+                              display: 'relative',
+                            }}>
+                            <img
+                              draggable='false'
+                              src='https://s2.loli.net/2024/10/26/iD1g23pnC9d6hVM.png'
+                              style={{
+                                height: '360px',
+                                filter:
+                                  'drop-shadow(0 0 5px rgba(var(--semi-grey-7))',
+                              }}
+                            />
+                            <div
+                              style={{
+                                position: 'absolute',
+                                left: '40px',
+                                bottom: '60px',
+                                height: '25px',
+                                display: 'flex',
+                                alignContent: 'center',
+                                filter:
+                                  'drop-shadow(0 0 5px rgba(var(--semi-grey-7))',
+                              }}>
+                              <img
+                                draggable='false'
+                                src='https://s2.loli.net/2024/10/27/c7QDINMXFyuav6b.png'
+                                style={{
+                                  filter: 'invert(100%)',
+                                  height: '25px',
+                                }}
                               />
-                            </TabPane>
-                            <TabPane
-                              tab={
-                                <Avatar
-                                  src={characterRegistry!["Ming"].attack?.skills.passive.skillIcon}
-                                  style={{ margin: '0 auto', height: "40px", width: "40px" }}
+                              <span
+                                style={{
+                                  fontSize: '18px',
+                                  margin: '1.5px',
+                                  marginLeft: '5px',
+                                  color: 'white',
+                                }}>
+                                <strong>决斗</strong>
+                              </span>
+                            </div>
+                            <div
+                              style={{
+                                position: 'absolute',
+                                left: '40px',
+                                bottom: '80px',
+                                height: '25px',
+                                display: 'flex',
+                                alignContent: 'center',
+                                filter:
+                                  'drop-shadow(0 0 5px rgba(var(--semi-grey-7))',
+                              }}>
+                              <span
+                                style={{
+                                  fontSize: '18px',
+                                  margin: '1.5px',
+                                  marginLeft: '5px',
+                                  color: 'white',
+                                }}>
+                                <strong>明</strong>
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            style={{
+                              width: '100%',
+                              fontSize: '10px',
+                              marginRight: '15px',
+                              marginTop: '3px',
+                            }}>
+                            <Tabs type='button'>
+                              <TabPane
+                                tab={
+                                  <Avatar
+                                    src={
+                                      characterRegistry!['Ming'].attack?.skills
+                                        .active.skillIcon
+                                    }
+                                    style={{
+                                      margin: '0 auto',
+                                      height: '40px',
+                                      width: '40px',
+                                    }}
+                                  />
+                                }
+                                itemKey='1'>
+                                <div
+                                  className='none-scrollbar'
+                                  style={{
+                                    margin: '2px',
+                                    height: '70px',
+                                    overflowY: 'scroll',
+                                  }}>
+                                  明发射一个电球，其达到最大距离、碰到敌方超弦体时会自动引爆，也可通过手动再次按下技能键后主动引爆。电球会破坏范围内所有敌方单位（包含召唤物）的护甲并造成减速。明进入电场将提升移动速度。
+                                </div>
+                                <Descriptions
+                                  className='none-scrollbar'
+                                  style={{
+                                    marginTop: '10px',
+                                    maxHeight: '190px',
+                                    overflowY: 'scroll',
+                                  }}
+                                  align='left'
+                                  data={[
+                                    { key: '冷却', value: '25秒' },
+                                    { key: '最远距离', value: '60米' },
+                                    { key: '最短起爆', value: '8米' },
+                                    { key: '作用范围', value: '半径5米' },
+                                    { key: '移速提升', value: '20%' },
+                                    { key: '移速提升', value: '20%' },
+                                    { key: '移速提升', value: '20%' },
+                                    { key: '移速提升', value: '20%' },
+                                  ]}
                                 />
-                              }
-                              itemKey="2"
-                            >
-                              <div style={{ margin: "3px" }}>
-                                明使用枪械和主动技能对敌方护甲或护盾造成伤害时，自己的护甲将得到基于该伤害量的回复。绝招持续时间内，被动会回复临时护甲并增加回复量。
-                              </div>
-                            </TabPane>
-                            <TabPane
-                              tab={
-                                <Avatar
-                                  src={characterRegistry!["Ming"].attack?.skills.ultimate.skillIcon}
-                                  style={{ margin: '0 auto', height: "40px", width: "40px" }}
-                                />
-                              }
-                              itemKey="3"
-                            >
-                              <div style={{ margin: "3px" }}>
-                                明获得临时护甲并使自己的射击附带可叠加的减速效果。明使用枪械和主动技能对敌人的护甲造成伤害时，可延长该技能持续时间并回复临时护甲。
-                              </div>
-                            </TabPane>
-                          </Tabs>
+                              </TabPane>
+                              <TabPane
+                                tab={
+                                  <Avatar
+                                    src={
+                                      characterRegistry!['Ming'].attack?.skills
+                                        .passive.skillIcon
+                                    }
+                                    style={{
+                                      margin: '0 auto',
+                                      height: '40px',
+                                      width: '40px',
+                                    }}
+                                  />
+                                }
+                                itemKey='2'>
+                                <div style={{ margin: '3px' }}>
+                                  明使用枪械和主动技能对敌方护甲或护盾造成伤害时，自己的护甲将得到基于该伤害量的回复。绝招持续时间内，被动会回复临时护甲并增加回复量。
+                                </div>
+                              </TabPane>
+                              <TabPane
+                                tab={
+                                  <Avatar
+                                    src={
+                                      characterRegistry!['Ming'].attack?.skills
+                                        .ultimate.skillIcon
+                                    }
+                                    style={{
+                                      margin: '0 auto',
+                                      height: '40px',
+                                      width: '40px',
+                                    }}
+                                  />
+                                }
+                                itemKey='3'>
+                                <div style={{ margin: '3px' }}>
+                                  明获得临时护甲并使自己的射击附带可叠加的减速效果。明使用枪械和主动技能对敌人的护甲造成伤害时，可延长该技能持续时间并回复临时护甲。
+                                </div>
+                              </TabPane>
+                            </Tabs>
+                          </div>
                         </div>
-                      </div>
-                    </Card>}
-                  >
-                    <span draggable onDragStart={(e) => onDragStart(e, key as string, 'attack')}>
+                      </Card>
+                    }>
+                    <span
+                      draggable
+                      onDragStart={(e) =>
+                        onDragStart(e, key as string, 'attack')
+                      }>
                       <Avatar
-                        src={characterRegistry![key as string].attack?.canvasImage}
+                        src={
+                          characterRegistry![key as string].attack?.canvasImage
+                        }
                         style={{ padding: '0.25rem' }}
                       />
                     </span>
                   </Popover>
                 </Col>
-              )
+              );
             })}
           </Row>
           <Divider dashed margin={'1rem'} />
-          <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+          <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
             {Object.keys(Urbino).map((key: unknown) => {
               return (
-                <Col span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
+                <Col
+                  span={6}
+                  style={{
+                    display: 'flex',
+                    placeItems: 'center',
+                    placeContent: 'center',
+                  }}>
                   <Tooltip position='topLeft' content={key as string}>
-                    <span draggable onDragStart={(e) => onDragStart(e, key as string, 'attack')}>
+                    <span
+                      draggable
+                      onDragStart={(e) =>
+                        onDragStart(e, key as string, 'attack')
+                      }>
                       <Avatar
-                        src={characterRegistry![key as string].attack?.canvasImage}
+                        src={
+                          characterRegistry![key as string].attack?.canvasImage
+                        }
                         style={{ padding: '0.25rem' }}
                       />
                     </span>
                   </Tooltip>
                 </Col>
-              )
+              );
             })}
           </Row>
         </TabPane>
         <TabPane
           tab={
             <span>
-              <GiShield style={{ margin: "0 auto" }} />
+              <GiShield style={{ margin: '0 auto' }} />
               {currentLanguageMode.sidebar.defense}
             </span>
           }
           itemKey='defense'>
-          <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+          <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
             {Object.keys(PUS).map((key: unknown) => {
               return (
-                <Col span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
+                <Col
+                  span={6}
+                  style={{
+                    display: 'flex',
+                    placeItems: 'center',
+                    placeContent: 'center',
+                  }}>
                   <Tooltip position='topLeft' content={key as string}>
-                    <span draggable onDragStart={(e) => onDragStart(e, key as string, 'defense')}>
+                    <span
+                      draggable
+                      onDragStart={(e) =>
+                        onDragStart(e, key as string, 'defense')
+                      }>
                       <Avatar
                         className='none-drag'
-                        src={characterRegistry![key as string].defense?.canvasImage}
+                        src={
+                          characterRegistry![key as string].defense?.canvasImage
+                        }
                         style={{ padding: '0.25rem' }}
                       />
                     </span>
                   </Tooltip>
                 </Col>
-              )
+              );
             })}
           </Row>
           <Divider dashed margin={'1rem'} />
-          <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+          <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
             {Object.keys(Urbino).map((key: unknown) => {
               return (
-                <Col span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
+                <Col
+                  span={6}
+                  style={{
+                    display: 'flex',
+                    placeItems: 'center',
+                    placeContent: 'center',
+                  }}>
                   <Tooltip position='topLeft' content={key as string}>
-                    <span draggable onDragStart={(e) => onDragStart(e, key as string, 'defense')}>
+                    <span
+                      draggable
+                      onDragStart={(e) =>
+                        onDragStart(e, key as string, 'defense')
+                      }>
                       <Avatar
-                        src={characterRegistry![key as string].defense?.canvasImage}
+                        src={
+                          characterRegistry![key as string].defense?.canvasImage
+                        }
                         style={{ padding: '0.25rem' }}
                       />
                     </span>
                   </Tooltip>
                 </Col>
-              )
+              );
             })}
           </Row>
         </TabPane>
         <TabPane
           tab={
             <span>
-              <GiStunGrenade style={{ margin: "0 auto" }} />
+              <GiStunGrenade style={{ margin: '0 auto' }} />
               {currentLanguageMode.sidebar.grenade}
             </span>
           }
           itemKey='grenade'>
-          <Row gutter={[16, 6]} style={{ width: '100%', margin: "0 auto" }}>
+          <Row gutter={[16, 6]} style={{ width: '100%', margin: '0 auto' }}>
             {grenadeData.map((grenade) => {
               return (
-                <Col span={6} style={{ display: 'flex', placeItems: 'center', placeContent: 'center' }}>
-                  <Tooltip position='topLeft' content={currentLanguageMode.grenades[grenade.grenade]}>
+                <Col
+                  span={6}
+                  style={{
+                    display: 'flex',
+                    placeItems: 'center',
+                    placeContent: 'center',
+                  }}>
+                  <Tooltip
+                    position='topLeft'
+                    content={currentLanguageMode.grenades[grenade.grenade]}>
                     <Avatar
                       src={grenade.imageLink}
-                      style={{ margin: '0.25rem', backgroundColor: "grey", height: "48px", width: "48px" }}
+                      style={{
+                        margin: '0.25rem',
+                        backgroundColor: 'grey',
+                        height: '48px',
+                        width: '48px',
+                      }}
                     />
                   </Tooltip>
                 </Col>
-              )
+              );
             })}
           </Row>
         </TabPane>
       </Tabs>
       <Divider margin={'1rem'} />
     </div>
-  )
-}
+  );
+};
 
-export default SiderContent
+export default SiderContent;

--- a/src/components/Layouts/SiderTools.tsx
+++ b/src/components/Layouts/SiderTools.tsx
@@ -1,38 +1,44 @@
-import React, { useContext, useLayoutEffect } from 'react'
-import { mapTools } from '../../utils/canvasConstants'
-import Pikaso, { BaseShapes, DrawType } from 'pikaso'
-import { MdDelete, MdDeleteForever, MdDraw, MdRedo, MdUndo } from 'react-icons/md'
-import ToolPopoverButton from './Buttons/tool-popover-button'
-import ToolTextPopoverButton from './Buttons/tool-popover-text-button'
-import ColorPopover from './Popovers/ColorPopover'
-import { FaMousePointer, FaUpload, FaDownload } from 'react-icons/fa'
-import { RxText } from "react-icons/rx"
-import ToolNormalButton from './Buttons/tool-normal-button'
-import { PiArrowRightFill, PiLineSegmentFill } from 'react-icons/pi'
-import ToolColorButton from './Buttons/tool-color-button'
-import { Popconfirm, Toast } from '@douyinfe/semi-ui'
-import { RiScreenshot2Fill } from "react-icons/ri";
-import html2canvas from 'html2canvas'
-import { LanguageContext } from '../../contexts/LanguageContext.ts'
+import React, { useContext, useLayoutEffect } from 'react';
+import { mapTools } from '../../utils/canvasConstants';
+import Pikaso, { BaseShapes, DrawType } from 'pikaso';
+import {
+  MdDelete,
+  MdDeleteForever,
+  MdDraw,
+  MdRedo,
+  MdUndo,
+} from 'react-icons/md';
+import ToolPopoverButton from './Buttons/tool-popover-button';
+import ToolTextPopoverButton from './Buttons/tool-popover-text-button';
+import ColorPopover from './Popovers/ColorPopover';
+import { FaMousePointer, FaUpload, FaDownload } from 'react-icons/fa';
+import { RxText } from 'react-icons/rx';
+import ToolNormalButton from './Buttons/tool-normal-button';
+import { PiArrowRightFill, PiLineSegmentFill } from 'react-icons/pi';
+import ToolColorButton from './Buttons/tool-color-button';
+import { Popconfirm, Toast } from '@douyinfe/semi-ui';
+import { RiScreenshot2Fill } from 'react-icons/ri';
+import html2canvas from 'html2canvas';
+import { LanguageContext } from '../../contexts/LanguageContext.ts';
 
 interface SiderToolsProps {
-  setTool: React.Dispatch<React.SetStateAction<mapTools>>
-  canvasTool: mapTools
-  setpenWidth: React.Dispatch<React.SetStateAction<number>>
-  penWidth: number
-  lineWidth: number
-  setLineWidth: React.Dispatch<React.SetStateAction<number>>
-  fontSize: number
-  setFontSize: React.Dispatch<React.SetStateAction<number>>
-  penColor: string
-  editor: Pikaso<BaseShapes> | null
-  setPenColor: React.Dispatch<React.SetStateAction<string>>
-  colors: Array<string>
-  setColors: React.Dispatch<React.SetStateAction<Array<string>>>
-  selectedColor: number
-  setSelectedColor: React.Dispatch<React.SetStateAction<number>>
-  save: React.Dispatch<React.SetStateAction<void>>
-  load: React.Dispatch<React.SetStateAction<void>>
+  setTool: React.Dispatch<React.SetStateAction<mapTools>>;
+  canvasTool: mapTools;
+  setpenWidth: React.Dispatch<React.SetStateAction<number>>;
+  penWidth: number;
+  lineWidth: number;
+  setLineWidth: React.Dispatch<React.SetStateAction<number>>;
+  fontSize: number;
+  setFontSize: React.Dispatch<React.SetStateAction<number>>;
+  penColor: string;
+  editor: Pikaso<BaseShapes> | null;
+  setPenColor: React.Dispatch<React.SetStateAction<string>>;
+  colors: Array<string>;
+  setColors: React.Dispatch<React.SetStateAction<Array<string>>>;
+  selectedColor: number;
+  setSelectedColor: React.Dispatch<React.SetStateAction<number>>;
+  save: React.Dispatch<React.SetStateAction<void>>;
+  load: React.Dispatch<React.SetStateAction<void>>;
 }
 
 const SiderTools: React.FC<SiderToolsProps> = ({
@@ -54,44 +60,101 @@ const SiderTools: React.FC<SiderToolsProps> = ({
   save,
   load,
 }) => {
-  const [togglevisible, setToggleVisible] = React.useState(false)
-  const [selection, setSelection] = React.useState(false)
+  const [togglevisible, setToggleVisible] = React.useState(false);
+  const [selection, setSelection] = React.useState(false);
 
-  const currentLanguage = useContext(LanguageContext)
+  const currentLanguage = useContext(LanguageContext);
 
   editor?.on('selection:change', (selection) => {
     if (selection.shapes!.length > 0) {
-      setSelection(true)
+      setSelection(true);
     } else {
-      setSelection(false)
+      setSelection(false);
     }
-  })
+  });
 
-  const refSelect = React.useRef<HTMLSpanElement>(null)
-  const refDraw = React.useRef<HTMLSpanElement>(null)
-  const refEdge = React.useRef<HTMLSpanElement>(null)
-  const refArrow = React.useRef<HTMLSpanElement>(null)
-  const refText = React.useRef<HTMLSpanElement>(null)
-  const refImageSave = React.useRef<HTMLSpanElement>(null)
-  const refLoad = React.useRef<HTMLSpanElement>(null)
-  const refSave = React.useRef<HTMLSpanElement>(null)
+  const refSelect = React.useRef<HTMLSpanElement>(null);
+  const refDraw = React.useRef<HTMLSpanElement>(null);
+  const refEdge = React.useRef<HTMLSpanElement>(null);
+  const refArrow = React.useRef<HTMLSpanElement>(null);
+  const refText = React.useRef<HTMLSpanElement>(null);
+  const refImageSave = React.useRef<HTMLSpanElement>(null);
+  const refLoad = React.useRef<HTMLSpanElement>(null);
+  const refSave = React.useRef<HTMLSpanElement>(null);
 
   useLayoutEffect(() => {
     const bindGlobalHotKeys = (e: KeyboardEvent) => {
-      if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.code === 'KeyS') { (refSelect.current?.firstChild as HTMLElement).click() }
-      else if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.code === 'KeyD') { (refDraw.current?.firstChild as HTMLElement).click() }
-      else if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.code === 'KeyE') { (refEdge.current?.firstChild as HTMLElement).click() }
-      else if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.code === 'KeyA') { (refArrow.current?.firstChild as HTMLElement).click() }
-      else if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.code === 'KeyT') { (refText.current?.firstChild as HTMLElement).click() }
-      else if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.code === 'KeyI') { e.preventDefault(); (refImageSave.current?.firstChild as HTMLElement).click() }
-      else if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.code === 'KeyS') { e.preventDefault(); (refSave.current?.firstChild as HTMLElement).click() }
-      else if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.code === 'KeyO') { e.preventDefault(); (refLoad.current?.firstChild as HTMLElement).click() }
-    }
-    document.body.addEventListener('keydown', bindGlobalHotKeys)
+      if (
+        !e.ctrlKey &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        e.code === 'KeyS'
+      ) {
+        (refSelect.current?.firstChild as HTMLElement).click();
+      } else if (
+        !e.ctrlKey &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        e.code === 'KeyD'
+      ) {
+        (refDraw.current?.firstChild as HTMLElement).click();
+      } else if (
+        !e.ctrlKey &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        e.code === 'KeyE'
+      ) {
+        (refEdge.current?.firstChild as HTMLElement).click();
+      } else if (
+        !e.ctrlKey &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        e.code === 'KeyA'
+      ) {
+        (refArrow.current?.firstChild as HTMLElement).click();
+      } else if (
+        !e.ctrlKey &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        e.code === 'KeyT'
+      ) {
+        (refText.current?.firstChild as HTMLElement).click();
+      } else if (
+        (e.ctrlKey || e.metaKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.code === 'KeyI'
+      ) {
+        e.preventDefault();
+        (refImageSave.current?.firstChild as HTMLElement).click();
+      } else if (
+        (e.ctrlKey || e.metaKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.code === 'KeyS'
+      ) {
+        e.preventDefault();
+        (refSave.current?.firstChild as HTMLElement).click();
+      } else if (
+        (e.ctrlKey || e.metaKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.code === 'KeyO'
+      ) {
+        e.preventDefault();
+        (refLoad.current?.firstChild as HTMLElement).click();
+      }
+    };
+    document.body.addEventListener('keydown', bindGlobalHotKeys);
     return () => {
-      document.body.removeEventListener('keydown', bindGlobalHotKeys)
-    }
-  }, [])
+      document.body.removeEventListener('keydown', bindGlobalHotKeys);
+    };
+  }, []);
 
   return (
     <div>
@@ -142,13 +205,12 @@ const SiderTools: React.FC<SiderToolsProps> = ({
           penColor={penColor}
         />
       </span>
-      <ColorPopover 
+      <ColorPopover
         setPenColor={setPenColor}
         colors={colors}
         setColors={setColors}
         selectedColor={selectedColor}
-        setSelectedColor={setSelectedColor}
-        >
+        setSelectedColor={setSelectedColor}>
         <div
           style={{
             width: '4rem',
@@ -157,13 +219,25 @@ const SiderTools: React.FC<SiderToolsProps> = ({
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            cursor: 'pointer'
+            cursor: 'pointer',
           }}>
-          <ToolColorButton color={penColor} onClick={() => undefined} text={penColor} />
+          <ToolColorButton
+            color={penColor}
+            onClick={() => undefined}
+            text={penColor}
+          />
         </div>
       </ColorPopover>
-      <ToolNormalButton Icon={MdUndo} isActiveTool={false} onClick={() => editor?.undo()} />
-      <ToolNormalButton Icon={MdRedo} isActiveTool={false} onClick={() => editor?.redo()} />
+      <ToolNormalButton
+        Icon={MdUndo}
+        isActiveTool={false}
+        onClick={() => editor?.undo()}
+      />
+      <ToolNormalButton
+        Icon={MdRedo}
+        isActiveTool={false}
+        onClick={() => editor?.redo()}
+      />
       <Popconfirm
         visible={togglevisible}
         title={currentLanguage.markbox.clearwarning.title}
@@ -171,25 +245,34 @@ const SiderTools: React.FC<SiderToolsProps> = ({
         okText={currentLanguage.markbox.clearwarning.ok}
         cancelText={currentLanguage.markbox.clearwarning.cancel}
         onConfirm={() => {
-          editor?.reset()
-          setToggleVisible(!togglevisible)
-          Toast.success(currentLanguage.markbox.clearwarning.success)
+          editor?.reset();
+          setToggleVisible(!togglevisible);
+          Toast.success(currentLanguage.markbox.clearwarning.success);
         }}
         onCancel={() => {
-          setToggleVisible(!togglevisible)
+          setToggleVisible(!togglevisible);
         }}
         position='left'>
         <ToolNormalButton
           Icon={selection ? MdDelete : MdDeleteForever}
           typeOverride={selection ? 'secondary' : 'danger'}
           isActiveTool={false}
-          onClick={() => (selection ? editor?.selection.delete() : setToggleVisible(!togglevisible))}
+          onClick={() =>
+            selection
+              ? editor?.selection.delete()
+              : setToggleVisible(!togglevisible)
+          }
         />
       </Popconfirm>
       <span ref={refImageSave}>
-        <ToolNormalButton Icon={RiScreenshot2Fill} isActiveTool={false} onClick={() => {
-          const MarkingCanvas = document.querySelector("#capture") as HTMLElement
-          /*
+        <ToolNormalButton
+          Icon={RiScreenshot2Fill}
+          isActiveTool={false}
+          onClick={() => {
+            const MarkingCanvas = document.querySelector(
+              '#capture',
+            ) as HTMLElement;
+            /*
           let Ink = document.createElement("span")
           Ink.appendChild(document.createTextNode("Strinova Map Assist"))
           Ink.style.position = "absolute"
@@ -199,25 +282,46 @@ const SiderTools: React.FC<SiderToolsProps> = ({
           Ink.style.margin = "10px"
           MarkingCanvas.appendChild(Ink)
           */
-          html2canvas(MarkingCanvas).then(canvas => {
-            const Presentdate = new Date()
-            const imgData = canvas
-            const link = document.createElement('a')
-            link.href = imgData.toDataURL()
-            const presenttime = Presentdate.getFullYear().toString() + (Presentdate.getMonth() + 1 < 10 ? "0" : "") + (Presentdate.getMonth() + 1).toString() + (Presentdate.getDate() < 10 ? "0" : "") + Presentdate.getDate().toString() + Presentdate.getHours().toString() + Presentdate.getMinutes().toString() + Presentdate.getSeconds().toString()
-            link.download = 'SMA_' + presenttime + '.png'
-            link.click()
-          })
-        }} />
+            html2canvas(MarkingCanvas).then((canvas) => {
+              const Presentdate = new Date();
+              const imgData = canvas;
+              const link = document.createElement('a');
+              link.href = imgData.toDataURL();
+              const presenttime =
+                Presentdate.getFullYear().toString() +
+                (Presentdate.getMonth() + 1 < 10 ? '0' : '') +
+                (Presentdate.getMonth() + 1).toString() +
+                (Presentdate.getDate() < 10 ? '0' : '') +
+                Presentdate.getDate().toString() +
+                Presentdate.getHours().toString() +
+                Presentdate.getMinutes().toString() +
+                Presentdate.getSeconds().toString();
+              link.download = 'SMA_' + presenttime + '.png';
+              link.click();
+            });
+          }}
+        />
       </span>
       <span ref={refLoad}>
-        <ToolNormalButton Icon={FaUpload} isActiveTool={false} onClick={() => { load() }} />
+        <ToolNormalButton
+          Icon={FaUpload}
+          isActiveTool={false}
+          onClick={() => {
+            load();
+          }}
+        />
       </span>
       <span ref={refSave}>
-        <ToolNormalButton Icon={FaDownload} isActiveTool={false} onClick={() => { save() }} />
+        <ToolNormalButton
+          Icon={FaDownload}
+          isActiveTool={false}
+          onClick={() => {
+            save();
+          }}
+        />
       </span>
     </div>
-  )
-}
+  );
+};
 
-export default SiderTools
+export default SiderTools;

--- a/src/components/Layouts/SkillSider.tsx
+++ b/src/components/Layouts/SkillSider.tsx
@@ -1,14 +1,17 @@
-import React from 'react'
-import Text from '@douyinfe/semi-ui/lib/es/typography/text'
-import SkillNormalButton from './Buttons/skill-normal-button'
-import { characterData } from '../../data/characters/characterRegistry'
+import React from 'react';
+import Text from '@douyinfe/semi-ui/lib/es/typography/text';
+import SkillNormalButton from './Buttons/skill-normal-button';
+import { characterData } from '../../data/characters/characterRegistry';
 
 interface SkillSiderProps {
-  selectedCharacter: characterData | null
-  currentSiderSide: 'attack' | 'defense'
+  selectedCharacter: characterData | null;
+  currentSiderSide: 'attack' | 'defense';
 }
 
-const SkillSider: React.FC<SkillSiderProps> = ({ selectedCharacter, currentSiderSide }) => {
+const SkillSider: React.FC<SkillSiderProps> = ({
+  selectedCharacter,
+  currentSiderSide,
+}) => {
   const noCharacterSelected = (
     <div
       style={{
@@ -18,15 +21,26 @@ const SkillSider: React.FC<SkillSiderProps> = ({ selectedCharacter, currentSider
         justifyContent: 'center',
         alignItems: 'center',
         width: '100%',
-        padding: '2rem 0'
+        padding: '2rem 0',
       }}>
       <Text weight={100} style={{ color: 'var(--semi-color-disabled-text)' }}>
         Drag a character from the sidebar to get started!
       </Text>
     </div>
-  )
+  );
 
-  return <div>{selectedCharacter ? <SkillNormalButton sideData={selectedCharacter[currentSiderSide]!} onClick={() => 0} /> : noCharacterSelected}</div>
-}
+  return (
+    <div>
+      {selectedCharacter ? (
+        <SkillNormalButton
+          sideData={selectedCharacter[currentSiderSide]!}
+          onClick={() => 0}
+        />
+      ) : (
+        noCharacterSelected
+      )}
+    </div>
+  );
+};
 
-export default SkillSider
+export default SkillSider;

--- a/src/components/announcement.tsx
+++ b/src/components/announcement.tsx
@@ -1,90 +1,119 @@
 import { useState } from 'react';
 import { Modal, Button, Typography, Divider, Tag } from '@douyinfe/semi-ui';
-import { MdOutlineAnnouncement, MdPushPin } from "react-icons/md";
+import { MdOutlineAnnouncement, MdPushPin } from 'react-icons/md';
 
 interface AnnouncementForm {
-    title: string
-    date: string
-    summary: string
-    data: object
+  title: string;
+  date: string;
+  summary: string;
+  data: object;
 }
 
 interface AnnouncementData {
-    notshowntoday: string
-    pin: AnnouncementForm
-    history: Array<AnnouncementForm> | null | undefined
+  notshowntoday: string;
+  pin: AnnouncementForm;
+  history: Array<AnnouncementForm> | null | undefined;
 }
 
 interface AnnouncementPops {
-    name: string;
-    content: AnnouncementData;
+  name: string;
+  content: AnnouncementData;
 }
 
 // 设置 cookie
 function setCookie(name: string, value: string, days: number) {
-    const expires = new Date();
-    expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
-    document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`;
+  const expires = new Date();
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
+  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`;
 }
 
 // 获取 cookie
 function getCookie(name: string) {
-    const matches = document.cookie.match(
-        new RegExp(
-            `(?:^|; )${name.replace(/([.$?*|{}()[\]\\/+^])/g, "\\$1")}=([^;]*)`
-        )
-    );
-    return matches ? decodeURIComponent(matches[1]) : undefined;
+  const matches = document.cookie.match(
+    new RegExp(
+      `(?:^|; )${name.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1')}=([^;]*)`,
+    ),
+  );
+  return matches ? decodeURIComponent(matches[1]) : undefined;
 }
 
 // 删除 cookie
 function deleteCookie(name: string) {
-    setCookie(name, "", -1);
+  setCookie(name, '', -1);
 }
 
 const { Title } = Typography;
 
 const Announcement = (props: AnnouncementPops) => {
-    const presentdate = new Date();
-    const [visible, setVisible] = useState(getCookie("today_announcement") ? (getCookie("today_announcement") === presentdate.getDate().toString() ? false : () => { deleteCookie("today_announcement"); return true }) : true);
-    const showDialog = () => {
-        setVisible(true);
-    };
-    const handleOk = () => {
-        setVisible(false);
-        if (!getCookie("today_announcement")) {
-            setCookie("today_announcement", presentdate.getDate().toString(), 1)
-        }
-    };
-    const handleCancel = () => {
-        setVisible(false);
-    };
-    const handleAfterClose = () => {
-        console.log('After Close callback executed');
-    };
+  const presentdate = new Date();
+  const [visible, setVisible] = useState(
+    getCookie('today_announcement')
+      ? getCookie('today_announcement') === presentdate.getDate().toString()
+        ? false
+        : () => {
+            deleteCookie('today_announcement');
+            return true;
+          }
+      : true,
+  );
+  const showDialog = () => {
+    setVisible(true);
+  };
+  const handleOk = () => {
+    setVisible(false);
+    if (!getCookie('today_announcement')) {
+      setCookie('today_announcement', presentdate.getDate().toString(), 1);
+    }
+  };
+  const handleCancel = () => {
+    setVisible(false);
+  };
+  const handleAfterClose = () => {
+    console.log('After Close callback executed');
+  };
 
-    return (
-        <>
-            <Button type="tertiary" onClick={showDialog} style={{ marginRight: "10px" }}><MdOutlineAnnouncement style={{ color: "rgba(var(--semi-grey-9), 1)", fontSize: "15px", marginRight: "5px", marginTop: "3px" }} />{props.name}</Button>
-            <Modal
-                title={props.name}
-                visible={visible}
-                onOk={handleOk}
-                afterClose={handleAfterClose} //>=1.16.0
-                onCancel={handleCancel}
-                closeOnEsc={true}
-                okText={props.content.notshowntoday}
-            >
-                <div>
-                    <div style={{ display: "flex" }}>
-                        <MdPushPin style={{ marginTop: "3px", marginRight: "5px", fontSize: "18px" }} /><Title heading={6}>{props.content.pin.title}<Tag shape='circle' color='cyan' style={{ marginLeft: "5px" }}>{props.content.pin.date}</Tag></Title>
-                    </div>
-                    <Divider margin='8px' />
-                    <div>{props.content.pin.summary}</div>
-                </div>
-            </Modal>
-        </>
-    );
+  return (
+    <>
+      <Button
+        type='tertiary'
+        onClick={showDialog}
+        style={{ marginRight: '10px' }}>
+        <MdOutlineAnnouncement
+          style={{
+            color: 'rgba(var(--semi-grey-9), 1)',
+            fontSize: '15px',
+            marginRight: '5px',
+            marginTop: '3px',
+          }}
+        />
+        {props.name}
+      </Button>
+      <Modal
+        title={props.name}
+        visible={visible}
+        onOk={handleOk}
+        afterClose={handleAfterClose} //>=1.16.0
+        onCancel={handleCancel}
+        closeOnEsc={true}
+        okText={props.content.notshowntoday}>
+        <div>
+          <div style={{ display: 'flex' }}>
+            <MdPushPin
+              style={{ marginTop: '3px', marginRight: '5px', fontSize: '18px' }}
+            />
+            <Title heading={6}>
+              {props.content.pin.title}
+              <Tag shape='circle' color='cyan' style={{ marginLeft: '5px' }}>
+                {props.content.pin.date}
+              </Tag>
+            </Title>
+          </div>
+          <Divider margin='8px' />
+          <div>{props.content.pin.summary}</div>
+        </div>
+      </Modal>
+    </>
+  );
 };
 
 export default Announcement;

--- a/src/components/appShell.tsx
+++ b/src/components/appShell.tsx
@@ -1,11 +1,17 @@
-
 import React, { useState, useLayoutEffect } from 'react';
 import { i18nData } from '../data/i18n';
 import { Layout, LocaleProvider } from '@douyinfe/semi-ui';
 import { characterRegistry } from '../data/characters/characterRegistry';
 import { MapName, mapList } from '../data/maplist';
 import { save, load, loadCurrentAppState } from '../data/stateManagement';
-import { initShare, share, rebindShare, cleanUpShare, updateLobbyRefs, updateLiveMap } from '../data/liveShare.ts';
+import {
+  initShare,
+  share,
+  rebindShare,
+  cleanUpShare,
+  updateLobbyRefs,
+  updateLiveMap,
+} from '../data/liveShare.ts';
 import { mapTools, loadColors } from '../utils/canvasConstants';
 import DrawMap from './Layouts/Canvas/drawCanvas';
 import MapCanvas from './Layouts/Canvas/mapCanvas';
@@ -14,10 +20,22 @@ import HeaderContent from './Layouts/HeaderContent';
 import SiderContent from './Layouts/Sider/SiderContent.tsx';
 import SiderTools from './Layouts/SiderTools';
 import usePikaso from 'pikaso-react-hook';
-import { getLanguage, LanguageContext, saveLanguage } from '../contexts/LanguageContext.ts'
-import { getTheme, saveTheme, ThemeContext, ThemeType } from '../contexts/ThemeContext.ts'
+import {
+  getLanguage,
+  LanguageContext,
+  saveLanguage,
+} from '../contexts/LanguageContext.ts';
+import {
+  getTheme,
+  saveTheme,
+  ThemeContext,
+  ThemeType,
+} from '../contexts/ThemeContext.ts';
 
-import { TbLayoutSidebarLeftCollapse, TbLayoutSidebarLeftExpand } from "react-icons/tb";
+import {
+  TbLayoutSidebarLeftCollapse,
+  TbLayoutSidebarLeftExpand,
+} from 'react-icons/tb';
 import { Languages } from '../types/interface.ts';
 
 import { Locale } from '@douyinfe/semi-ui/lib/es/locale/interface';
@@ -26,232 +44,314 @@ import zh_CN from '@douyinfe/semi-ui/lib/es/locale/source/zh_CN';
 import ja_JP from '@douyinfe/semi-ui/lib/es/locale/source/ja_JP';
 
 interface AppShellProps {
-	characterData: characterRegistry
+  characterData: characterRegistry;
 }
 
 const AppShell: React.FC<AppShellProps> = ({ characterData }) => {
-	const [drawCanvasRef, drawCanvasEditor] = usePikaso({
-		width: 1000,
-		height: 1000,
-		selection: {
-			transformer: {
-				borderStroke: 'rgba(77, 238, 234, 1)',
-				anchorStroke: 'rgba(77, 238, 234, 1)',
-				anchorFill: 'rgba(77, 238, 234, 1)'
-			},
-			zone: {
-				fill: 'rgba(77, 238, 234, 0.1)',
-				stroke: 'rgba(77, 238, 234, 1)'
-			}
-		}
-	})
-	const [drawMapRef, drawMapEditor] = usePikaso({
-		width: 1000,
-		height: 1000,
-		selection: {
-			interactive: false,
-			keyboard: {
-				enabled: false
-			}
-		},
-		disableCanvasContextMenu: true,
-		history: {
-			keyboard: {
-				enabled: false
-			}
-		}
-	})
+  const [drawCanvasRef, drawCanvasEditor] = usePikaso({
+    width: 1000,
+    height: 1000,
+    selection: {
+      transformer: {
+        borderStroke: 'rgba(77, 238, 234, 1)',
+        anchorStroke: 'rgba(77, 238, 234, 1)',
+        anchorFill: 'rgba(77, 238, 234, 1)',
+      },
+      zone: {
+        fill: 'rgba(77, 238, 234, 0.1)',
+        stroke: 'rgba(77, 238, 234, 1)',
+      },
+    },
+  });
+  const [drawMapRef, drawMapEditor] = usePikaso({
+    width: 1000,
+    height: 1000,
+    selection: {
+      interactive: false,
+      keyboard: {
+        enabled: false,
+      },
+    },
+    disableCanvasContextMenu: true,
+    history: {
+      keyboard: {
+        enabled: false,
+      },
+    },
+  });
 
-	const [presentLanguage, setPresentLanguage] = useState<Languages>(getLanguage)
-	const [presentMap, setPresentMap] = useState(MapName.WindyTown)
-	const [presentTheme, setPresentTheme] = useState<ThemeType>(getTheme)
-	const [panelcollaps, setPanelcollaps] = useState(false)
+  const [presentLanguage, setPresentLanguage] =
+    useState<Languages>(getLanguage);
+  const [presentMap, setPresentMap] = useState(MapName.WindyTown);
+  const [presentTheme, setPresentTheme] = useState<ThemeType>(getTheme);
+  const [panelcollaps, setPanelcollaps] = useState(false);
 
-	const colorPalette = loadColors()
-	const [canvasTool, setTool] = useState<mapTools>('SELECT')
-	const [penColor, setpenColor] = useState(colorPalette[2])
-	const [colors, setColors] = useState<Array<string>>(colorPalette)
-	const [selectedColor, setSelectedColor] = useState(-1)
+  const colorPalette = loadColors();
+  const [canvasTool, setTool] = useState<mapTools>('SELECT');
+  const [penColor, setpenColor] = useState(colorPalette[2]);
+  const [colors, setColors] = useState<Array<string>>(colorPalette);
+  const [selectedColor, setSelectedColor] = useState(-1);
 
-	const [penWidth, setpenWidth] = useState(2)
-	const [lineWidth, setLineWidth] = useState(2)
-	const [fontSize, setFontSize] = useState(2)
+  const [penWidth, setpenWidth] = useState(2);
+  const [lineWidth, setLineWidth] = useState(2);
+  const [fontSize, setFontSize] = useState(2);
 
-	const [mapPrepareMode, setMapPrepareMode] = useState(true)
-	const [presentMapURL, setPresentMapURL] = useState({
-		imgPrepareLink: mapList[0].imgPrepareLink,
-		imgBlankLink: mapList[0].imgBlankLink
-	})
+  const [mapPrepareMode, setMapPrepareMode] = useState(true);
+  const [presentMapURL, setPresentMapURL] = useState({
+    imgPrepareLink: mapList[0].imgPrepareLink,
+    imgBlankLink: mapList[0].imgBlankLink,
+  });
 
-	const { Header, Footer, Sider, Content } = Layout
+  const { Header, Footer, Sider, Content } = Layout;
 
-	const currentLanguage = i18nData[presentLanguage as keyof typeof i18nData]
+  const currentLanguage = i18nData[presentLanguage as keyof typeof i18nData];
 
-	document.body.setAttribute("theme-mode", presentTheme)
+  document.body.setAttribute('theme-mode', presentTheme);
 
-	const setLanguage = (lang: Languages) => {
-		setPresentLanguage(lang)
-		saveLanguage(lang)
-	}
+  const setLanguage = (lang: Languages) => {
+    setPresentLanguage(lang);
+    saveLanguage(lang);
+  };
 
-	const setTheme = (theme: ThemeType) => {
-		setPresentTheme(theme)
-		saveTheme(theme)
-		document.body.setAttribute("theme-mode", theme)
-	}
+  const setTheme = (theme: ThemeType) => {
+    setPresentTheme(theme);
+    saveTheme(theme);
+    document.body.setAttribute('theme-mode', theme);
+  };
 
-	const saveFile = () => {
-		save({ presentMap, mapPrepareMode, drawCanvasEditor })
-	}
+  const saveFile = () => {
+    save({ presentMap, mapPrepareMode, drawCanvasEditor });
+  };
 
-	const loadFile = () => {
-		load({ setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor })
-	}
+  const loadFile = () => {
+    load({
+      setPresentMap,
+      setPresentMapURL,
+      setMapPrepareMode,
+      drawCanvasEditor,
+    });
+  };
 
-	const loadJson = (json: any) => {
-		loadCurrentAppState({ json, setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor })
-	}
+  const loadJson = (json: any) => {
+    loadCurrentAppState({
+      json,
+      setPresentMap,
+      setPresentMapURL,
+      setMapPrepareMode,
+      drawCanvasEditor,
+    });
+  };
 
-	const liveShare = () => {
-		share({ ui: true })
-	}
-	
-	useLayoutEffect(() => {
-		const onHashChange = () => { share()}
-		if(drawCanvasEditor) {
-			initShare({ presentMap, setPresentMap, setPresentMapURL, mapPrepareMode, setMapPrepareMode, drawCanvasEditor })
-			if (location.hash) {
-				share()
-			}
-			window.addEventListener('hashchange', onHashChange)
-		}
-		 return () => {
-			window.removeEventListener('hashchange', onHashChange)
-			cleanUpShare()
-		}
-	}, [drawCanvasEditor])
+  const liveShare = () => {
+    share({ ui: true });
+  };
 
-	useLayoutEffect(() => {
-		updateLobbyRefs({presentMap, mapPrepareMode})
-		rebindShare()
-		updateLiveMap()
-	}, [presentMap, setPresentMap, presentMapURL, setPresentMapURL, mapPrepareMode, setMapPrepareMode])
+  useLayoutEffect(() => {
+    const onHashChange = () => {
+      share();
+    };
+    if (drawCanvasEditor) {
+      initShare({
+        presentMap,
+        setPresentMap,
+        setPresentMapURL,
+        mapPrepareMode,
+        setMapPrepareMode,
+        drawCanvasEditor,
+      });
+      if (location.hash) {
+        share();
+      }
+      window.addEventListener('hashchange', onHashChange);
+    }
+    return () => {
+      window.removeEventListener('hashchange', onHashChange);
+      cleanUpShare();
+    };
+  }, [drawCanvasEditor]);
 
-	const canvases = (
-		<div id="capture" style={{ overflow: 'hidden', position: 'relative', top: 0, left: 0, width: '100%', height: '100%' }}>
-			<div className='no-select' style={{ position: "absolute", bottom: "20px", opacity: 0.1, fontSize: "25px", marginLeft: "30px" }}>
-				<div>Strinova Map Assistant</div>
-				<div style={{ fontSize: "18px" }}>strinova.fsltech.cn</div>
-			</div>
-			<MapCanvas
-				currentMap={mapPrepareMode ? presentMapURL.imgPrepareLink : presentMapURL.imgBlankLink}
-				pikasoEditor={drawMapEditor}
-				pikasoRef={drawMapRef}
-				style={{ position: 'absolute', top: '0', left: '0' }}
-				panelcollaps={panelcollaps}
-			/>
-			<DrawMap
-				pikasoRef={drawCanvasRef}
-				pikasoEditor={drawCanvasEditor}
-				currentMap={mapPrepareMode ? presentMapURL.imgPrepareLink : presentMapURL.imgBlankLink}
-				canvasTool={canvasTool}
-				setTool={setTool}
-				lineWidth={lineWidth}
-				fontSize={fontSize}
-				penColor={penColor}
-				penWidth={penWidth}
-				load={loadJson}
-				panelcollaps={panelcollaps}
-			/>
-		</div>
-	);
+  useLayoutEffect(() => {
+    updateLobbyRefs({ presentMap, mapPrepareMode });
+    rebindShare();
+    updateLiveMap();
+  }, [
+    presentMap,
+    setPresentMap,
+    presentMapURL,
+    setPresentMapURL,
+    mapPrepareMode,
+    setMapPrepareMode,
+  ]);
 
-	const localeMap: {
-		[key in Languages]: Locale
-	} = {
-		English: en_US,
-		日本語: ja_JP,
-		简体中文: zh_CN
-	}
+  const canvases = (
+    <div
+      id='capture'
+      style={{
+        overflow: 'hidden',
+        position: 'relative',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      }}>
+      <div
+        className='no-select'
+        style={{
+          position: 'absolute',
+          bottom: '20px',
+          opacity: 0.1,
+          fontSize: '25px',
+          marginLeft: '30px',
+        }}>
+        <div>Strinova Map Assistant</div>
+        <div style={{ fontSize: '18px' }}>strinova.fsltech.cn</div>
+      </div>
+      <MapCanvas
+        currentMap={
+          mapPrepareMode
+            ? presentMapURL.imgPrepareLink
+            : presentMapURL.imgBlankLink
+        }
+        pikasoEditor={drawMapEditor}
+        pikasoRef={drawMapRef}
+        style={{ position: 'absolute', top: '0', left: '0' }}
+        panelcollaps={panelcollaps}
+      />
+      <DrawMap
+        pikasoRef={drawCanvasRef}
+        pikasoEditor={drawCanvasEditor}
+        currentMap={
+          mapPrepareMode
+            ? presentMapURL.imgPrepareLink
+            : presentMapURL.imgBlankLink
+        }
+        canvasTool={canvasTool}
+        setTool={setTool}
+        lineWidth={lineWidth}
+        fontSize={fontSize}
+        penColor={penColor}
+        penWidth={penWidth}
+        load={loadJson}
+        panelcollaps={panelcollaps}
+      />
+    </div>
+  );
 
-	return (
-		<LocaleProvider locale={localeMap[presentLanguage]}>
-			<LanguageContext.Provider value={currentLanguage}>
-				<ThemeContext.Provider value={presentTheme}>
-					<Layout
-						style={{
-							border: '1px solid var(--semi-color-border)',
-							height: '100%',
-							width: '100%',
-						}}>
-						<Header style={{ backgroundColor: 'var(--semi-color-bg-1)' }}>
-							{/* This takes language mode because of the language switcher */}
-							<HeaderContent
-								editor={drawCanvasEditor}
-								currentMap={presentMap}
-								changeLanguage={setLanguage}
-								changeTheme={setTheme}
-								setPresentMap={setPresentMap}
-								setPresentMapURL={setPresentMapURL}
-								mapPrepareMode={mapPrepareMode}
-								setMapPrepareMode={setMapPrepareMode}
-								share={liveShare}
-							/>
-						</Header>
-						<Layout>
-							<Sider style={{ backgroundColor: 'var(--semi-color-bg-1)', height: "100%", position: "relative" }}>
-								<SiderContent characterRegistry={characterData} collaps={panelcollaps} />
-								<button
-									style={{ position: "absolute", width: "50px", height: "50px", backgroundColor: "var(--semi-color-bg-1)", color: "var(--semi-color-bg-7)" }}
-									onClick={() => setPanelcollaps(!panelcollaps)}>
-									{panelcollaps ? <TbLayoutSidebarLeftExpand /> : <TbLayoutSidebarLeftCollapse />}
-								</button>
-							</Sider>
-							<Content
-								style={{
-									backgroundColor: 'var(--semi-color-bg-2)',
-									height: '100%',
-									width: "100%",
-									display: 'flex',
-									placeItems: 'center',
-									padding: '0 auto'
-								}}>
-								{canvases}
-							</Content>
-							<span className='minHeightAvailable' style={{ overflowX: 'hidden', overflowY: 'auto', maxHeight: 'calc(100svh - 7.5rem)', minWidth:'4rem' }}>
-								<span style={{display: 'table'}}>
-									<Sider style={{ backgroundColor: 'var(--semi-color-bg-1)', width: '4rem' }}>
-										<SiderTools
-											canvasTool={canvasTool}
-											setTool={setTool}
-											penColor={penColor}
-											penWidth={penWidth}
-											setpenWidth={setpenWidth}
-											setLineWidth={setLineWidth}
-											lineWidth={lineWidth}
-											fontSize={fontSize}
-											setFontSize={setFontSize}
-											editor={drawCanvasEditor}
-											setPenColor={setpenColor}
-											colors={colors}
-											setColors={setColors}
-											selectedColor={selectedColor}
-											setSelectedColor={setSelectedColor}
-											save={saveFile}
-											load={loadFile}
-										/>
-									</Sider>
-								</span>
-							</span>
-						</Layout>
-						<Footer style={{ backgroundColor: 'var(--semi-color-bg-1)' }}>
-							<FooterContent />
-						</Footer>
-					</Layout>
-				</ThemeContext.Provider>
-			</LanguageContext.Provider>
-		</LocaleProvider>
-	);
+  const localeMap: {
+    [key in Languages]: Locale;
+  } = {
+    English: en_US,
+    日本語: ja_JP,
+    简体中文: zh_CN,
+  };
+
+  return (
+    <LocaleProvider locale={localeMap[presentLanguage]}>
+      <LanguageContext.Provider value={currentLanguage}>
+        <ThemeContext.Provider value={presentTheme}>
+          <Layout
+            style={{
+              border: '1px solid var(--semi-color-border)',
+              height: '100%',
+              width: '100%',
+            }}>
+            <Header style={{ backgroundColor: 'var(--semi-color-bg-1)' }}>
+              {/* This takes language mode because of the language switcher */}
+              <HeaderContent
+                editor={drawCanvasEditor}
+                currentMap={presentMap}
+                changeLanguage={setLanguage}
+                changeTheme={setTheme}
+                setPresentMap={setPresentMap}
+                setPresentMapURL={setPresentMapURL}
+                mapPrepareMode={mapPrepareMode}
+                setMapPrepareMode={setMapPrepareMode}
+                share={liveShare}
+              />
+            </Header>
+            <Layout>
+              <Sider
+                style={{
+                  backgroundColor: 'var(--semi-color-bg-1)',
+                  height: '100%',
+                  position: 'relative',
+                }}>
+                <SiderContent
+                  characterRegistry={characterData}
+                  collaps={panelcollaps}
+                />
+                <button
+                  style={{
+                    position: 'absolute',
+                    width: '50px',
+                    height: '50px',
+                    backgroundColor: 'var(--semi-color-bg-1)',
+                    color: 'var(--semi-color-bg-7)',
+                  }}
+                  onClick={() => setPanelcollaps(!panelcollaps)}>
+                  {panelcollaps ? (
+                    <TbLayoutSidebarLeftExpand />
+                  ) : (
+                    <TbLayoutSidebarLeftCollapse />
+                  )}
+                </button>
+              </Sider>
+              <Content
+                style={{
+                  backgroundColor: 'var(--semi-color-bg-2)',
+                  height: '100%',
+                  width: '100%',
+                  display: 'flex',
+                  placeItems: 'center',
+                  padding: '0 auto',
+                }}>
+                {canvases}
+              </Content>
+              <span
+                className='minHeightAvailable'
+                style={{
+                  overflowX: 'hidden',
+                  overflowY: 'auto',
+                  maxHeight: 'calc(100svh - 7.5rem)',
+                  minWidth: '4rem',
+                }}>
+                <span style={{ display: 'table' }}>
+                  <Sider
+                    style={{
+                      backgroundColor: 'var(--semi-color-bg-1)',
+                      width: '4rem',
+                    }}>
+                    <SiderTools
+                      canvasTool={canvasTool}
+                      setTool={setTool}
+                      penColor={penColor}
+                      penWidth={penWidth}
+                      setpenWidth={setpenWidth}
+                      setLineWidth={setLineWidth}
+                      lineWidth={lineWidth}
+                      fontSize={fontSize}
+                      setFontSize={setFontSize}
+                      editor={drawCanvasEditor}
+                      setPenColor={setpenColor}
+                      colors={colors}
+                      setColors={setColors}
+                      selectedColor={selectedColor}
+                      setSelectedColor={setSelectedColor}
+                      save={saveFile}
+                      load={loadFile}
+                    />
+                  </Sider>
+                </span>
+              </span>
+            </Layout>
+            <Footer style={{ backgroundColor: 'var(--semi-color-bg-1)' }}>
+              <FooterContent />
+            </Footer>
+          </Layout>
+        </ThemeContext.Provider>
+      </LanguageContext.Provider>
+    </LocaleProvider>
+  );
 };
 
 export default AppShell;

--- a/src/components/buttons/changeHighlightButton.tsx
+++ b/src/components/buttons/changeHighlightButton.tsx
@@ -1,13 +1,17 @@
-import { Button } from '@douyinfe/semi-ui'
-import React from 'react'
+import { Button } from '@douyinfe/semi-ui';
+import React from 'react';
 
 interface ChangeHighlightButtonProps {
-  content: string
-  mapPrepareMode: boolean
-  setMapPrepareMode: React.Dispatch<React.SetStateAction<boolean>>
+  content: string;
+  mapPrepareMode: boolean;
+  setMapPrepareMode: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const ChangeHighlightButton: React.FC<ChangeHighlightButtonProps> = ({ mapPrepareMode, setMapPrepareMode, content }) => {
+const ChangeHighlightButton: React.FC<ChangeHighlightButtonProps> = ({
+  mapPrepareMode,
+  setMapPrepareMode,
+  content,
+}) => {
   return (
     <Button
       theme={mapPrepareMode ? 'solid' : 'outline'}
@@ -15,7 +19,7 @@ const ChangeHighlightButton: React.FC<ChangeHighlightButtonProps> = ({ mapPrepar
       onClick={() => setMapPrepareMode(!mapPrepareMode)}>
       {content}
     </Button>
-  )
-}
+  );
+};
 
-export default ChangeHighlightButton
+export default ChangeHighlightButton;

--- a/src/components/buttons/changeMapButton.tsx
+++ b/src/components/buttons/changeMapButton.tsx
@@ -1,16 +1,18 @@
-import React from 'react'
-import { I18nData } from '../../types/interface'
-import { Button, Dropdown } from '@douyinfe/semi-ui'
-import { FaMap } from 'react-icons/fa'
-import { mapList, MapName } from '../../data/maplist'
-import Pikaso, { BaseShapes } from 'pikaso'
+import React from 'react';
+import { I18nData } from '../../types/interface';
+import { Button, Dropdown } from '@douyinfe/semi-ui';
+import { FaMap } from 'react-icons/fa';
+import { mapList, MapName } from '../../data/maplist';
+import Pikaso, { BaseShapes } from 'pikaso';
 
 interface ChangeMapButtonProps {
-  currentLanguage: I18nData
-  currentMap: MapName
-  setPresentMap: React.Dispatch<React.SetStateAction<MapName>>
-  setPresentMapURL: React.Dispatch<React.SetStateAction<{ imgPrepareLink: string; imgBlankLink: string }>>
-  editor: Pikaso<BaseShapes> | null
+  currentLanguage: I18nData;
+  currentMap: MapName;
+  setPresentMap: React.Dispatch<React.SetStateAction<MapName>>;
+  setPresentMapURL: React.Dispatch<
+    React.SetStateAction<{ imgPrepareLink: string; imgBlankLink: string }>
+  >;
+  editor: Pikaso<BaseShapes> | null;
 }
 
 const ChangeMapButton: React.FC<ChangeMapButtonProps> = ({
@@ -18,17 +20,20 @@ const ChangeMapButton: React.FC<ChangeMapButtonProps> = ({
   currentMap,
   setPresentMap,
   setPresentMapURL,
-  editor
+  editor,
 }) => {
   const changePresentmap = (value: string) => {
-    setPresentMap(MapName[value as keyof typeof MapName])
+    setPresentMap(MapName[value as keyof typeof MapName]);
     for (const mapinfo of mapList) {
       if (mapinfo.map === value) {
-        editor?.reset()
-        setPresentMapURL({ imgPrepareLink: mapinfo.imgPrepareLink, imgBlankLink: mapinfo.imgBlankLink })
+        editor?.reset();
+        setPresentMapURL({
+          imgPrepareLink: mapinfo.imgPrepareLink,
+          imgBlankLink: mapinfo.imgBlankLink,
+        });
       }
     }
-  }
+  };
 
   return (
     <div>
@@ -39,7 +44,9 @@ const ChangeMapButton: React.FC<ChangeMapButtonProps> = ({
         render={
           <Dropdown.Menu>
             {Object.keys(MapName).map((key: unknown) => (
-              <Dropdown.Item key={key as MapName} onClick={() => changePresentmap(key as MapName)}>
+              <Dropdown.Item
+                key={key as MapName}
+                onClick={() => changePresentmap(key as MapName)}>
                 {currentLanguage.mapsetting.maps[key as MapName]}
               </Dropdown.Item>
             ))}
@@ -50,7 +57,7 @@ const ChangeMapButton: React.FC<ChangeMapButtonProps> = ({
         </Button>
       </Dropdown>
     </div>
-  )
-}
+  );
+};
 
-export default ChangeMapButton
+export default ChangeMapButton;

--- a/src/components/buttons/characterBtn.tsx
+++ b/src/components/buttons/characterBtn.tsx
@@ -1,51 +1,61 @@
-import { Badge } from '@douyinfe/semi-ui'
-import Pikaso, { BaseShapes } from 'pikaso'
+import { Badge } from '@douyinfe/semi-ui';
+import Pikaso, { BaseShapes } from 'pikaso';
 
 interface CharactorBtnPops {
-    imglink?: string
-    badge?: string | null
-    pikasoEditor: Pikaso<BaseShapes> | null
+  imglink?: string;
+  badge?: string | null;
+  pikasoEditor: Pikaso<BaseShapes> | null;
 }
 
 const draggableBtnStyle = {
-    borderRadius: '100%',
-    margin: '3px',
-    width: '35px',
-    height: '35px',
-    display: 'flex',
-    placeItems: 'center',
-    placeContent: 'center',
-    backgroundColor: 'rgba(var(--semi-grey-2), 1)',
-    boxShadow: '0 0 0 3px rgba(var(--semi-grey-1), 1)',
-    overflow: 'hidden'
-}
+  borderRadius: '100%',
+  margin: '3px',
+  width: '35px',
+  height: '35px',
+  display: 'flex',
+  placeItems: 'center',
+  placeContent: 'center',
+  backgroundColor: 'rgba(var(--semi-grey-2), 1)',
+  boxShadow: '0 0 0 3px rgba(var(--semi-grey-1), 1)',
+  overflow: 'hidden',
+};
 
 const CharacterBtn = (props: CharactorBtnPops) => {
+  const addToCanvas = () => {
+    props.pikasoEditor?.shapes.image.insert(props.imglink!, {
+      width: 40,
+      height: 40,
+      x: 100,
+      y: 100,
+    });
+  };
 
-    const addToCanvas = () => {
-        props.pikasoEditor?.shapes.image.insert(props.imglink!, {
-            width: 40,
-            height: 40,
-            x: 100,
-            y: 100
-        })
-    }
+  return (
+    <>
+      {props.badge != null ? (
+        <Badge
+          count={props.badge}
+          position='rightBottom'
+          type={props.badge === '×' ? 'danger' : 'secondary'}>
+          <div style={draggableBtnStyle}>
+            <img
+              src={props.imglink}
+              style={{ width: '100%', height: '100%' }}
+              onClick={addToCanvas}
+            />
+          </div>
+        </Badge>
+      ) : (
+        <div style={draggableBtnStyle}>
+          <img
+            src={props.imglink}
+            style={{ width: '100%', height: '100%' }}
+            onClick={addToCanvas}
+          />
+        </div>
+      )}
+    </>
+  );
+};
 
-    return (
-        <>
-            {props.badge != null ? (
-                <Badge count={props.badge} position='rightBottom' type={props.badge === '×' ? 'danger' : 'secondary'}>
-                    <div style={draggableBtnStyle}>
-                        <img src={props.imglink} style={{ width: '100%', height: '100%' }} onClick={addToCanvas} />
-                    </div>
-                </Badge>
-            ) : (
-                <div style={draggableBtnStyle}>
-                    <img src={props.imglink} style={{ width: '100%', height: '100%' }} onClick={addToCanvas} />
-                </div>
-            )}
-        </>
-    )
-}
-
-export default CharacterBtn
+export default CharacterBtn;

--- a/src/components/buttons/colorBtn.tsx
+++ b/src/components/buttons/colorBtn.tsx
@@ -1,10 +1,20 @@
 interface ColorBtnPops {
-    color?: string;
-    linercolor?: string;
+  color?: string;
+  linercolor?: string;
 }
 
 const ColorBtn = (props: ColorBtnPops) => {
-    return <div style={{ backgroundColor: props.color,background:"linear-gradient(" + props.linercolor + ")", width: "24px", height: "24px", borderRadius: "100%", boxShadow: "0 0 0 3px rgba(var(--semi-grey-2), 1)", }}></div>
-}
+  return (
+    <div
+      style={{
+        backgroundColor: props.color,
+        background: 'linear-gradient(' + props.linercolor + ')',
+        width: '24px',
+        height: '24px',
+        borderRadius: '100%',
+        boxShadow: '0 0 0 3px rgba(var(--semi-grey-2), 1)',
+      }}></div>
+  );
+};
 
 export default ColorBtn;

--- a/src/components/buttons/grenadeBtn.tsx
+++ b/src/components/buttons/grenadeBtn.tsx
@@ -1,27 +1,45 @@
 import { Badge } from '@douyinfe/semi-ui';
 
 interface GrenadeBtnPops {
-    imglink?: string;
-    badge?: string | null;
+  imglink?: string;
+  badge?: string | null;
 }
 
 const draggableBtnStyle = {
-    borderRadius: "100%",
-    margin: "3px",
-    width: "35px",
-    height: "35px",
-    display: 'flex',
-    placeItems: 'center',
-    placeContent: 'center',
-    backgroundColor: "rgba(var(--semi-grey-6), 1)",
-    boxShadow: "0 0 0 3px rgba(var(--semi-grey-1), 1)",
-    overflow: "hidden",
-}
+  borderRadius: '100%',
+  margin: '3px',
+  width: '35px',
+  height: '35px',
+  display: 'flex',
+  placeItems: 'center',
+  placeContent: 'center',
+  backgroundColor: 'rgba(var(--semi-grey-6), 1)',
+  boxShadow: '0 0 0 3px rgba(var(--semi-grey-1), 1)',
+  overflow: 'hidden',
+};
 
 const GrenadeBtn = (props: GrenadeBtnPops) => {
-    return <>
-        {props.badge != null ? <Badge count={props.badge} position='rightBottom' type={props.badge==='×'?'danger':'secondary'}><div style={draggableBtnStyle}><img src={props.imglink} style={{ width: '100%', height: '100%' }} /></div></Badge> : <div style={draggableBtnStyle}><img src={props.imglink} style={{ width: '100%', height: '100%' }} /></div>}
+  return (
+    <>
+      {props.badge != null ? (
+        <Badge
+          count={props.badge}
+          position='rightBottom'
+          type={props.badge === '×' ? 'danger' : 'secondary'}>
+          <div style={draggableBtnStyle}>
+            <img
+              src={props.imglink}
+              style={{ width: '100%', height: '100%' }}
+            />
+          </div>
+        </Badge>
+      ) : (
+        <div style={draggableBtnStyle}>
+          <img src={props.imglink} style={{ width: '100%', height: '100%' }} />
+        </div>
+      )}
     </>
-}
+  );
+};
 
 export default GrenadeBtn;

--- a/src/components/buttons/skillBtn.tsx
+++ b/src/components/buttons/skillBtn.tsx
@@ -1,29 +1,60 @@
 import { Badge } from '@douyinfe/semi-ui';
 
 interface SkillBtnPops {
-    imglink?: string;
-    badge?: string | null;
-    top?: string;
-    left?: string;
+  imglink?: string;
+  badge?: string | null;
+  top?: string;
+  left?: string;
 }
 
 const draggableBtnStyle = {
-    borderRadius: "100%",
-    margin: "3px",
-    width: "35px",
-    height: "35px",
-    display: 'flex',
-    placeItems: 'center',
-    placeContent: 'center',
-    backgroundColor: "rgba(var(--semi-grey-0), 1)",
-    boxShadow: "0 0 0 3px rgba(var(--semi-grey-1), 1)",
-    overflow: "hidden",
-}
+  borderRadius: '100%',
+  margin: '3px',
+  width: '35px',
+  height: '35px',
+  display: 'flex',
+  placeItems: 'center',
+  placeContent: 'center',
+  backgroundColor: 'rgba(var(--semi-grey-0), 1)',
+  boxShadow: '0 0 0 3px rgba(var(--semi-grey-1), 1)',
+  overflow: 'hidden',
+};
 
 const SkillBtn = (props: SkillBtnPops) => {
-    return <>
-        {props.badge != null ? <Badge count={props.badge} position='rightBottom' type={props.badge === '×' ? 'danger' : 'secondary'}><div style={draggableBtnStyle}><img src={props.imglink} style={{ width: '90%', height: '90%', marginTop: props.top, marginLeft: props.left }} /></div></Badge> : <div style={draggableBtnStyle}><img src={props.imglink} style={{ width: '90%', height: '90%', marginTop: props.top, marginLeft: props.left }} /></div>}
+  return (
+    <>
+      {props.badge != null ? (
+        <Badge
+          count={props.badge}
+          position='rightBottom'
+          type={props.badge === '×' ? 'danger' : 'secondary'}>
+          <div style={draggableBtnStyle}>
+            <img
+              src={props.imglink}
+              style={{
+                width: '90%',
+                height: '90%',
+                marginTop: props.top,
+                marginLeft: props.left,
+              }}
+            />
+          </div>
+        </Badge>
+      ) : (
+        <div style={draggableBtnStyle}>
+          <img
+            src={props.imglink}
+            style={{
+              width: '90%',
+              height: '90%',
+              marginTop: props.top,
+              marginLeft: props.left,
+            }}
+          />
+        </div>
+      )}
     </>
-}
+  );
+};
 
 export default SkillBtn;

--- a/src/components/contributors.tsx
+++ b/src/components/contributors.tsx
@@ -1,104 +1,255 @@
 import { Col, Row, Tag } from '@douyinfe/semi-ui';
 import { FaGithub, FaTwitch } from 'react-icons/fa';
-import { FaBilibili, FaXTwitter } from "react-icons/fa6";
+import { FaBilibili, FaXTwitter } from 'react-icons/fa6';
 
 interface ContributeBoxPops {
-    learnmore?: string;
+  learnmore?: string;
 }
 
 const contributeList = [
-    {
-        job: ["sponser", "code"],
-        name: "爱走位的KN",
-        icon: "https://avatars.githubusercontent.com/u/83012768?v=4",
-        github: "https://github.com/ShrLeeKNsword/",
-        bili: "https://space.bilibili.com/403314450",
-        X: "",
-        twich: "",
-    },
-    {
-        job: ["code", "translation"],
-        name: "MiekoHikari",
-        icon: "https://avatars.githubusercontent.com/u/77004524?v=4",
-        github: "https://github.com/MiekoHikari/",
-        bili: "",
-        X: "https://x.com/MiekoHikariEN",
-        twich: "https://www.twitch.tv/miekohikari",
-    },
-    {
-        job: ["translation"],
-        name: "サルミナ(salutemenow)",
-        icon: "https://s2.loli.net/2024/09/28/58XqieRV36aOCUx.webp",
-        github: "",
-        bili: "",
-        X: "https://x.com/salutemenowjp",
-        twich: "https://www.twitch.tv/salute_me_now_",
-    },
-    {
-        job: ["translation"],
-        name: "restart0x",
-        icon: "https://s2.loli.net/2024/11/08/HgB9Dqo6CPsL7Ql.jpg",
-        github: "",
-        bili: "https://space.bilibili.com/497387234",
-        X: "",
-        twich: "",
-    },
-    {
-        job: ["code"],
-        name: "Sheppsu",
-        icon: "https://avatars.githubusercontent.com/u/49356627?v=4",
-        github: "https://github.com/Sheppsu",
-        bili: "",
-        X: "",
-        twich: "",
-    },
-    {
-        job: ["code"],
-        name: "Jsynk",
-        icon: "https://avatars.githubusercontent.com/u/14832958?v=4",
-        github: "https://github.com/Jsynk",
-        bili: "",
-        X: "",
-        twich: "",
-    },
-    {
-        job: ["code"],
-        name: "Haru Yakumo",
-        icon: "https://cdn.sa.net/2025/04/22/fF9G5vbJRCckiLI.webp",
-        github: "https://github.com/huequica",
-        bili: "",
-        X: "https://x.com/huequica",
-        twich: "https://twitch.tv/huequica",
-    },
-]
+  {
+    job: ['sponser', 'code'],
+    name: '爱走位的KN',
+    icon: 'https://avatars.githubusercontent.com/u/83012768?v=4',
+    github: 'https://github.com/ShrLeeKNsword/',
+    bili: 'https://space.bilibili.com/403314450',
+    X: '',
+    twich: '',
+  },
+  {
+    job: ['code', 'translation'],
+    name: 'MiekoHikari',
+    icon: 'https://avatars.githubusercontent.com/u/77004524?v=4',
+    github: 'https://github.com/MiekoHikari/',
+    bili: '',
+    X: 'https://x.com/MiekoHikariEN',
+    twich: 'https://www.twitch.tv/miekohikari',
+  },
+  {
+    job: ['translation'],
+    name: 'サルミナ(salutemenow)',
+    icon: 'https://s2.loli.net/2024/09/28/58XqieRV36aOCUx.webp',
+    github: '',
+    bili: '',
+    X: 'https://x.com/salutemenowjp',
+    twich: 'https://www.twitch.tv/salute_me_now_',
+  },
+  {
+    job: ['translation'],
+    name: 'restart0x',
+    icon: 'https://s2.loli.net/2024/11/08/HgB9Dqo6CPsL7Ql.jpg',
+    github: '',
+    bili: 'https://space.bilibili.com/497387234',
+    X: '',
+    twich: '',
+  },
+  {
+    job: ['code'],
+    name: 'Sheppsu',
+    icon: 'https://avatars.githubusercontent.com/u/49356627?v=4',
+    github: 'https://github.com/Sheppsu',
+    bili: '',
+    X: '',
+    twich: '',
+  },
+  {
+    job: ['code'],
+    name: 'Jsynk',
+    icon: 'https://avatars.githubusercontent.com/u/14832958?v=4',
+    github: 'https://github.com/Jsynk',
+    bili: '',
+    X: '',
+    twich: '',
+  },
+  {
+    job: ['code'],
+    name: 'Haru Yakumo',
+    icon: 'https://cdn.sa.net/2025/04/22/fF9G5vbJRCckiLI.webp',
+    github: 'https://github.com/huequica',
+    bili: '',
+    X: 'https://x.com/huequica',
+    twich: 'https://twitch.tv/huequica',
+  },
+];
 
 const ContributeBox = (props: ContributeBoxPops) => {
-    return <div style={{ maxHeight: "800px", width: "400px", paddingTop: "5px", paddingBottom: "5px" }}>
-        <div className='none-scrollbar' style={{ height: "100%", width: "100%", overflowY: "scroll" }}>
-            {contributeList.map((child) => {
-                return <div key={child.name} style={{ height: "60px", width: "100%", display: "flex", alignItems: "center", justifyContent: "center", padding: "5px", color: "rgba(var(--semi-grey-9), 1)" }}>
-                    <Row style={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center", textAlign: "center" }}>
-                        <Col span={1}></Col>
-                        <Col span={4}><img src={child.icon} style={{ height: "50px", borderRadius: "50%", marginRight: "10px" }}></img></Col>
-                        <Col span={10} style={{ textAlign: "left", fontSize: "15px", fontWeight: "bold" }}>
-                            <div style={{ width: "100%", marginBottom: "3px", marginTop: "3px" }}>{child.name}</div>
-                            {child.job.map((childchild) => {
-                                return <Tag size="small" color='light-blue' style={{ marginRight: "5px", marginBottom: "2px", marginTop: "2px" }}>{childchild}</Tag>
-                            })}
-                        </Col>
-                        <Col span={7} style={{ textAlign: "right", display: "flex", alignItems: "right", justifyContent: "right" }}>
-                            {child.github != "" ? <a href={child.github} target='_blank' style={{ margin: "5px" }}><FaGithub /></a> : <div style={{ width: "25px", height: "100%", textAlign: "center", marginTop: "2px" }}>/</div>}
-                            {child.bili != "" ? <a href={child.bili} target='_blank' style={{ margin: "5px" }}><FaBilibili /></a> : <div style={{ width: "25px", height: "100%", textAlign: "center", marginTop: "2px" }}>/</div>}
-                            {child.X != "" ? <a href={child.X} target='_blank' style={{ margin: "5px" }}><FaXTwitter /></a> : <div style={{ width: "25px", height: "100%", textAlign: "center", marginTop: "2px" }}>/</div>}
-                            {child.twich != "" ? <a href={child.twich} target='_blank' style={{ margin: "5px" }}><FaTwitch /></a> : <div style={{ width: "25px", height: "100%", textAlign: "center", marginTop: "2px" }}>/</div>}
-                        </Col>
-                        <Col span={2} style={{}}></Col>
-                    </Row>
-                </div>
-            })}
+  return (
+    <div
+      style={{
+        maxHeight: '800px',
+        width: '400px',
+        paddingTop: '5px',
+        paddingBottom: '5px',
+      }}>
+      <div
+        className='none-scrollbar'
+        style={{ height: '100%', width: '100%', overflowY: 'scroll' }}>
+        {contributeList.map((child) => {
+          return (
+            <div
+              key={child.name}
+              style={{
+                height: '60px',
+                width: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '5px',
+                color: 'rgba(var(--semi-grey-9), 1)',
+              }}>
+              <Row
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  textAlign: 'center',
+                }}>
+                <Col span={1}></Col>
+                <Col span={4}>
+                  <img
+                    src={child.icon}
+                    style={{
+                      height: '50px',
+                      borderRadius: '50%',
+                      marginRight: '10px',
+                    }}></img>
+                </Col>
+                <Col
+                  span={10}
+                  style={{
+                    textAlign: 'left',
+                    fontSize: '15px',
+                    fontWeight: 'bold',
+                  }}>
+                  <div
+                    style={{
+                      width: '100%',
+                      marginBottom: '3px',
+                      marginTop: '3px',
+                    }}>
+                    {child.name}
+                  </div>
+                  {child.job.map((childchild) => {
+                    return (
+                      <Tag
+                        size='small'
+                        color='light-blue'
+                        style={{
+                          marginRight: '5px',
+                          marginBottom: '2px',
+                          marginTop: '2px',
+                        }}>
+                        {childchild}
+                      </Tag>
+                    );
+                  })}
+                </Col>
+                <Col
+                  span={7}
+                  style={{
+                    textAlign: 'right',
+                    display: 'flex',
+                    alignItems: 'right',
+                    justifyContent: 'right',
+                  }}>
+                  {child.github != '' ? (
+                    <a
+                      href={child.github}
+                      target='_blank'
+                      style={{ margin: '5px' }}>
+                      <FaGithub />
+                    </a>
+                  ) : (
+                    <div
+                      style={{
+                        width: '25px',
+                        height: '100%',
+                        textAlign: 'center',
+                        marginTop: '2px',
+                      }}>
+                      /
+                    </div>
+                  )}
+                  {child.bili != '' ? (
+                    <a
+                      href={child.bili}
+                      target='_blank'
+                      style={{ margin: '5px' }}>
+                      <FaBilibili />
+                    </a>
+                  ) : (
+                    <div
+                      style={{
+                        width: '25px',
+                        height: '100%',
+                        textAlign: 'center',
+                        marginTop: '2px',
+                      }}>
+                      /
+                    </div>
+                  )}
+                  {child.X != '' ? (
+                    <a href={child.X} target='_blank' style={{ margin: '5px' }}>
+                      <FaXTwitter />
+                    </a>
+                  ) : (
+                    <div
+                      style={{
+                        width: '25px',
+                        height: '100%',
+                        textAlign: 'center',
+                        marginTop: '2px',
+                      }}>
+                      /
+                    </div>
+                  )}
+                  {child.twich != '' ? (
+                    <a
+                      href={child.twich}
+                      target='_blank'
+                      style={{ margin: '5px' }}>
+                      <FaTwitch />
+                    </a>
+                  ) : (
+                    <div
+                      style={{
+                        width: '25px',
+                        height: '100%',
+                        textAlign: 'center',
+                        marginTop: '2px',
+                      }}>
+                      /
+                    </div>
+                  )}
+                </Col>
+                <Col span={2} style={{}}></Col>
+              </Row>
+            </div>
+          );
+        })}
+      </div>
+      {props.learnmore != '' || props.learnmore != undefined ? (
+        <div
+          style={{
+            fontSize: '15px',
+            fontWeight: 'bold',
+            textAlign: 'center',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '30px',
+            margin: '5px',
+            color: 'rgba(var(--semi-grey-9), 1)',
+          }}>
+          {props.learnmore}
         </div>
-        {props.learnmore != "" || props.learnmore != undefined ? <div style={{ fontSize: "15px", fontWeight: "bold", textAlign: 'center', display: "flex", alignItems: "center", justifyContent: "center", height: "30px", margin: "5px", color: "rgba(var(--semi-grey-9), 1)" }}>{props.learnmore}</div> : <></>}
+      ) : (
+        <></>
+      )}
     </div>
-}
+  );
+};
 
 export default ContributeBox;

--- a/src/contexts/LanguageContext.ts
+++ b/src/contexts/LanguageContext.ts
@@ -1,19 +1,19 @@
-import { createContext } from 'react'
-import { i18nData } from '../data/i18n.tsx'
-import { Languages } from '../types/interface.ts'
+import { createContext } from 'react';
+import { i18nData } from '../data/i18n.tsx';
+import { Languages } from '../types/interface.ts';
 
 export function getLanguage(): Languages {
-  const language = window.localStorage.getItem("language")
+  const language = window.localStorage.getItem('language');
 
   if (language && Object.values(Languages).includes(language as Languages)) {
-    return language as Languages
+    return language as Languages;
   }
 
-  return Languages.en_US
+  return Languages.en_US;
 }
 
 export function saveLanguage(lang: Languages) {
-  window.localStorage.setItem("language", lang.toString())
+  window.localStorage.setItem('language', lang.toString());
 }
 
-export const LanguageContext = createContext(i18nData[getLanguage()])
+export const LanguageContext = createContext(i18nData[getLanguage()]);

--- a/src/contexts/ThemeContext.ts
+++ b/src/contexts/ThemeContext.ts
@@ -1,17 +1,16 @@
-import { createContext } from 'react'
+import { createContext } from 'react';
 
-export type ThemeType = "dark" | "light"
+export type ThemeType = 'dark' | 'light';
 
 export function getTheme(): ThemeType {
-  return (
-    window.localStorage.getItem("theme") ?? (
-      window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light"
-    )
-  ) as ThemeType
+  return (window.localStorage.getItem('theme') ??
+    (window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light')) as ThemeType;
 }
 
 export function saveTheme(theme: ThemeType) {
-  window.localStorage.setItem("theme", theme)
+  window.localStorage.setItem('theme', theme);
 }
 
-export const ThemeContext = createContext(getTheme())
+export const ThemeContext = createContext(getTheme());

--- a/src/data/characters/PUS/Flavia.tsx
+++ b/src/data/characters/PUS/Flavia.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, PUS } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
 
 const character: characterData = {
-	faction: factions.PUS,
-	id: PUS.Flavia,
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/jC98Rq3NhrUXYWK.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/ZcVRCBUJ8PGwn46.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/58dg6OpPntlviqW.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/u5tV9xaNyjUL6EM.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/ezsVQS62bY5iBcG.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/lYbBufA6raXvQ1n.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.PUS,
+  id: PUS.Flavia,
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/jC98Rq3NhrUXYWK.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/ZcVRCBUJ8PGwn46.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/58dg6OpPntlviqW.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/u5tV9xaNyjUL6EM.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/ezsVQS62bY5iBcG.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/lYbBufA6raXvQ1n.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/PUS/Kokona.tsx
+++ b/src/data/characters/PUS/Kokona.tsx
@@ -1,47 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, PUS } from "../factions";
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
 
 const character: characterData = {
-	faction: factions.PUS,
-	id: PUS.Kokona,
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/jtlryiY8WHIGAMq.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/nEpdV1chgeNuiry.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/9zFsMYumpwJZrTg.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/V8NijM5onGulX9m.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/tilQp18zRheBMaJ.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/7lenAEosyt96kbZ.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.PUS,
+  id: PUS.Kokona,
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/jtlryiY8WHIGAMq.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/nEpdV1chgeNuiry.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/9zFsMYumpwJZrTg.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/V8NijM5onGulX9m.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/tilQp18zRheBMaJ.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/7lenAEosyt96kbZ.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/PUS/Leona.tsx
+++ b/src/data/characters/PUS/Leona.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, PUS } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
 
 const character: characterData = {
-	faction: factions.PUS,
-	id: PUS.Leona,
-	defense: {
-		canvasImage: 'https://cdn.sa.net/2025/01/23/WY9ijCwS7e4OPNM.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/snfMAvm1384Qc5h.png',
-		skills: {
-			active: {
-				skillIcon: 'https://cdn.sa.net/2025/01/23/8bA3kca54WlQi96.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://cdn.sa.net/2025/01/23/A45ZR1MXwovaijc.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://cdn.sa.net/2025/01/23/snt2Q9EovlWj7Nx.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2025/01/23/so6fhJX7Lp1YAPN.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.PUS,
+  id: PUS.Leona,
+  defense: {
+    canvasImage: 'https://cdn.sa.net/2025/01/23/WY9ijCwS7e4OPNM.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/snfMAvm1384Qc5h.png',
+    skills: {
+      active: {
+        skillIcon: 'https://cdn.sa.net/2025/01/23/8bA3kca54WlQi96.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://cdn.sa.net/2025/01/23/A45ZR1MXwovaijc.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://cdn.sa.net/2025/01/23/snt2Q9EovlWj7Nx.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2025/01/23/so6fhJX7Lp1YAPN.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/PUS/Michele.tsx
+++ b/src/data/characters/PUS/Michele.tsx
@@ -1,46 +1,46 @@
-import { characterData } from "../characterRegistry";
-import { factions, PUS } from "../factions";
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
 
 const character: characterData = {
-	faction: factions.PUS,
-	id: PUS.Michele,
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/29JH5SlaTdCwgFR.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/2MLSe7fg8tsQ3br.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/8iCzWDaNQPSxqvw.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/ANhKZ6GDzOIjPtf.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/UGeEvYfXiSgD4zr.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/fvrVnE8Ocl21Dpz.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.PUS,
+  id: PUS.Michele,
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/29JH5SlaTdCwgFR.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/2MLSe7fg8tsQ3br.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/8iCzWDaNQPSxqvw.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/ANhKZ6GDzOIjPtf.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/UGeEvYfXiSgD4zr.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/fvrVnE8Ocl21Dpz.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/PUS/Nobunaga.tsx
+++ b/src/data/characters/PUS/Nobunaga.tsx
@@ -1,47 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, PUS } from "../factions";
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
 
 const character: characterData = {
-		faction: factions.PUS,
-		id: PUS.Nobunaga,
-		defense: {
-			canvasImage: 'https://s2.loli.net/2024/09/29/7UuX5VTR8AYWD2o.png',
-			bodyImage: 'https://cdn.sa.net/2025/04/22/nvuOWPyjXK3Fif9.png',
-			skills: {
-				active: {
-					skillIcon: 'https://s2.loli.net/2024/09/25/VJFzGhSyXmsiHpO.png',
-					generateOnCanvas: active
-				},
-				passive: {
-					skillIcon: 'https://s2.loli.net/2024/09/25/AHsc9o8W25UlpNa.png',
-					generateOnCanvas: passive
-				},
-				ultimate: {
-					skillIcon: 'https://s2.loli.net/2024/09/25/Vr78sb9T32ADMuy.png',
-					generateOnCanvas: ultimate
-				},
-				sub: {
-					skillIcon: 'https://cdn.sa.net/2024/11/19/MTjuAvcKSq6RNiU.png',
-					generateOnCanvas: sub
-				}
-			}
-		}
-}
+  faction: factions.PUS,
+  id: PUS.Nobunaga,
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/7UuX5VTR8AYWD2o.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/nvuOWPyjXK3Fif9.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/VJFzGhSyXmsiHpO.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/AHsc9o8W25UlpNa.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/Vr78sb9T32ADMuy.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/MTjuAvcKSq6RNiU.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/PUS/Yugiri.tsx
+++ b/src/data/characters/PUS/Yugiri.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, PUS } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
 
 const character: characterData = {
-	faction: factions.PUS,
-	id: PUS.Yugiri,
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/11/10/Jq58o4vKDYUCcl1.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/JZ2543e9CUYDh8p.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/11/10/oW4UsSziGHnhLx2.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/11/10/jBC3dyGxKzmpQf2.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/11/10/T3huK4YzAXmrV8N.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/T4QIuUewCitmjbM.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.PUS,
+  id: PUS.Yugiri,
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/11/10/Jq58o4vKDYUCcl1.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/JZ2543e9CUYDh8p.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/11/10/oW4UsSziGHnhLx2.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/11/10/jBC3dyGxKzmpQf2.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/11/10/T3huK4YzAXmrV8N.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/T4QIuUewCitmjbM.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/PUS/Yvette.tsx
+++ b/src/data/characters/PUS/Yvette.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, PUS } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
 
 const character: characterData = {
-	faction: factions.PUS,
-	id: PUS.Yvette,
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/eIVFmswk3tUlOcR.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/AjGNVF4JLazbfHP.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/ESH6FNKQjbafMZn.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/2hqoyUWsnbA83BP.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/32VnSv59tPwTIhl.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/Hzo6W4y8ib5ceqf.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.PUS,
+  id: PUS.Yvette,
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/eIVFmswk3tUlOcR.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/AjGNVF4JLazbfHP.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/ESH6FNKQjbafMZn.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/2hqoyUWsnbA83BP.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/32VnSv59tPwTIhl.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/Hzo6W4y8ib5ceqf.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Eika.tsx
+++ b/src/data/characters/TheScissors/Eika.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Eika,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/SrnDsxX5bAiBNcE.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/SMVIPh4fqWzRruy.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/SPYXJZwHGObnrmV.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/JYfa5PdE6r4Kcio.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/sFgyUNK7iWtcvfp.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/to7dWPDVuUFRsIn.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Eika,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/SrnDsxX5bAiBNcE.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/SMVIPh4fqWzRruy.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/SPYXJZwHGObnrmV.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/JYfa5PdE6r4Kcio.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/sFgyUNK7iWtcvfp.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/to7dWPDVuUFRsIn.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Fragrans.tsx
+++ b/src/data/characters/TheScissors/Fragrans.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Fragrans,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/AM58XCKyixJlTGO.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/6cwHibDP9QmfuVC.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/L9j3uWBrl5hNyzx.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/B3HDdTpLjAyYQ74.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/5Xk9PUOlwFsgE6B.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/JrTleR2xkfPysaA.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Fragrans,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/AM58XCKyixJlTGO.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/6cwHibDP9QmfuVC.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/L9j3uWBrl5hNyzx.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/B3HDdTpLjAyYQ74.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/5Xk9PUOlwFsgE6B.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/JrTleR2xkfPysaA.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Kanami.tsx
+++ b/src/data/characters/TheScissors/Kanami.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Kanami,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/7DHOLqvWMzmlch3.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/v843gf6RWlFsPx7.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/UBJqoYz835GvVxy.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/OHbINYGSQhFazcd.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/YH3Phg5XQumsbCM.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/jOP3fQIlYxCvZSN.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Kanami,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/7DHOLqvWMzmlch3.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/v843gf6RWlFsPx7.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/UBJqoYz835GvVxy.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/OHbINYGSQhFazcd.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/YH3Phg5XQumsbCM.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/jOP3fQIlYxCvZSN.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Lawine.tsx
+++ b/src/data/characters/TheScissors/Lawine.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Lawine,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/DeK5afJoAhpyNcM.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/f8dgSBZ2zsvV1jL.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/gOFlGIzPjxbpYKw.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/8AxLszwVIg17WGq.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/HuEnVYb8Mr5e24I.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/E5OzUcFg3DsjGuH.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Lawine,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/DeK5afJoAhpyNcM.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/f8dgSBZ2zsvV1jL.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/gOFlGIzPjxbpYKw.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/8AxLszwVIg17WGq.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/HuEnVYb8Mr5e24I.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/E5OzUcFg3DsjGuH.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Mara.tsx
+++ b/src/data/characters/TheScissors/Mara.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Mara,
-	attack: {
-		canvasImage: 'https://cdn.sa.net/2025/04/22/ZKzhmI6U3lPcLb5.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/Y5fqMzeLCNB63dT.png',
-		skills: {
-			active: {
-				skillIcon: 'https://cdn.sa.net/2025/04/22/WNG8b9KAy154uLj.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://cdn.sa.net/2025/04/22/agB2vCobZk4efJM.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://cdn.sa.net/2025/04/22/vDMeEWlitLqTBIQ.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2025/04/22/cK4BS6k3DXndMjx.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Mara,
+  attack: {
+    canvasImage: 'https://cdn.sa.net/2025/04/22/ZKzhmI6U3lPcLb5.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/Y5fqMzeLCNB63dT.png',
+    skills: {
+      active: {
+        skillIcon: 'https://cdn.sa.net/2025/04/22/WNG8b9KAy154uLj.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://cdn.sa.net/2025/04/22/agB2vCobZk4efJM.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://cdn.sa.net/2025/04/22/vDMeEWlitLqTBIQ.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2025/04/22/cK4BS6k3DXndMjx.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Meredith.tsx
+++ b/src/data/characters/TheScissors/Meredith.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Meredith,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/C4QmVOhp1rB9Gd6.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/UvzslOa738JMjBn.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/KWYZTSQmjOHJ2RX.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/O8kRqCVEDoK6T3p.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/V8KZrx9sY7QBlaP.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/7sSae9nRhO2Ddzg.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Meredith,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/C4QmVOhp1rB9Gd6.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/UvzslOa738JMjBn.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/KWYZTSQmjOHJ2RX.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/O8kRqCVEDoK6T3p.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/V8KZrx9sY7QBlaP.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/7sSae9nRhO2Ddzg.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Ming.tsx
+++ b/src/data/characters/TheScissors/Ming.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Ming,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/nuhFZjpVGgJSEyc.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/tgNeOR5Iow6Cakc.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/NQ2TdSqhseRZY7b.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/bsAzZemy4uEcaHt.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/B6KC72wphAdt4Ri.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/CkhMrw23RbmBv5T.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Ming,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/nuhFZjpVGgJSEyc.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/tgNeOR5Iow6Cakc.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/NQ2TdSqhseRZY7b.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/bsAzZemy4uEcaHt.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/B6KC72wphAdt4Ri.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/CkhMrw23RbmBv5T.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/TheScissors/Reiichi.tsx
+++ b/src/data/characters/TheScissors/Reiichi.tsx
@@ -1,48 +1,47 @@
-import { characterData } from "../characterRegistry";
-import { factions, TheScissors } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, TheScissors } from '../factions';
 
 const character: characterData = {
-	faction: factions.TheScissors,
-	id: TheScissors.Reiichi,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/txSOyYkT4pXhGBn.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/Tu2C4q3OdFX6Ulk.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/C6qts5xeVpS1N4E.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/iuSvZDYnFTzmBrl.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/bESOlDh9oURvFC3.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/daOIybnpUr8QtVz.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.TheScissors,
+  id: TheScissors.Reiichi,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/txSOyYkT4pXhGBn.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/Tu2C4q3OdFX6Ulk.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/C6qts5xeVpS1N4E.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/iuSvZDYnFTzmBrl.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/bESOlDh9oURvFC3.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/daOIybnpUr8QtVz.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/Urbino/Audrey.tsx
+++ b/src/data/characters/Urbino/Audrey.tsx
@@ -1,70 +1,69 @@
-import { characterData } from "../characterRegistry";
-import { factions, Urbino } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, Urbino } from '../factions';
 
 const character: characterData = {
-	faction: factions.Urbino,
-	id: Urbino.Audrey,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/qD7YufUpTmbzX1x.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/GAv1ONZDR4sphmM.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/26/9PqOBd7owjJrRVp.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/26/pfyJk2RLYsXlBFg.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/26/E6tTWi1Suls5Y9R.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/iUDp2MuxwXVcd7a.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/IVhuSTZvYmk4CNj.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/GAv1ONZDR4sphmM.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/26/9PqOBd7owjJrRVp.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/26/pfyJk2RLYsXlBFg.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/26/E6tTWi1Suls5Y9R.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/iUDp2MuxwXVcd7a.png',
-				generateOnCanvas: sub
-			}
-		}
-	}
-}
+  faction: factions.Urbino,
+  id: Urbino.Audrey,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/qD7YufUpTmbzX1x.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/GAv1ONZDR4sphmM.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/26/9PqOBd7owjJrRVp.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/26/pfyJk2RLYsXlBFg.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/26/E6tTWi1Suls5Y9R.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/iUDp2MuxwXVcd7a.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/IVhuSTZvYmk4CNj.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/GAv1ONZDR4sphmM.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/26/9PqOBd7owjJrRVp.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/26/pfyJk2RLYsXlBFg.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/26/E6tTWi1Suls5Y9R.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/iUDp2MuxwXVcd7a.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/Urbino/BaiMo.tsx
+++ b/src/data/characters/Urbino/BaiMo.tsx
@@ -1,70 +1,69 @@
-import { characterData } from "../characterRegistry";
-import { factions, Urbino } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, Urbino } from '../factions';
 
 const character: characterData = {
-	faction: factions.Urbino,
-	id: Urbino.BaiMo,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/jt4621ivFRfbEqD.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/o5QTWCxraMFvZuw.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/eUzu75aSXVw2kQF.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/xvVheX57uGJMI2k.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/VkyGJKzHYr4pnlm.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/y1ojEJpIOrqbfUm.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/2KrCPXp5k1e6wfm.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/o5QTWCxraMFvZuw.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/eUzu75aSXVw2kQF.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/xvVheX57uGJMI2k.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/VkyGJKzHYr4pnlm.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/y1ojEJpIOrqbfUm.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-}
+  faction: factions.Urbino,
+  id: Urbino.BaiMo,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/jt4621ivFRfbEqD.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/o5QTWCxraMFvZuw.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/eUzu75aSXVw2kQF.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/xvVheX57uGJMI2k.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/VkyGJKzHYr4pnlm.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/y1ojEJpIOrqbfUm.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/2KrCPXp5k1e6wfm.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/o5QTWCxraMFvZuw.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/eUzu75aSXVw2kQF.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/xvVheX57uGJMI2k.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/VkyGJKzHYr4pnlm.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/y1ojEJpIOrqbfUm.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/Urbino/Celestia.tsx
+++ b/src/data/characters/Urbino/Celestia.tsx
@@ -1,70 +1,69 @@
-import { characterData } from "../characterRegistry";
-import { factions, Urbino } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, Urbino } from '../factions';
 
 const character: characterData = {
-	faction: factions.Urbino,
-	id: Urbino.Celestia,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/PI6eiLuZfcAQ2aR.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/xYLHks7NzduUmWP.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/WmtSU2hFLBPaf85.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/O5dXCxh3R1wVINQ.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/bJalMyBfZ7iXVtx.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/xm5Io68zcXSZAn1.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/Zt93QEgreUnvaxX.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/xYLHks7NzduUmWP.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/WmtSU2hFLBPaf85.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/O5dXCxh3R1wVINQ.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/bJalMyBfZ7iXVtx.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/xm5Io68zcXSZAn1.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-}
+  faction: factions.Urbino,
+  id: Urbino.Celestia,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/PI6eiLuZfcAQ2aR.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/xYLHks7NzduUmWP.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/WmtSU2hFLBPaf85.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/O5dXCxh3R1wVINQ.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/bJalMyBfZ7iXVtx.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/xm5Io68zcXSZAn1.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/Zt93QEgreUnvaxX.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/xYLHks7NzduUmWP.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/WmtSU2hFLBPaf85.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/O5dXCxh3R1wVINQ.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/bJalMyBfZ7iXVtx.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/xm5Io68zcXSZAn1.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/Urbino/Fuchsia.tsx
+++ b/src/data/characters/Urbino/Fuchsia.tsx
@@ -1,70 +1,69 @@
-import { characterData } from "../characterRegistry";
-import { factions, Urbino } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, Urbino } from '../factions';
 
 const character: characterData = {
-	faction: factions.Urbino,
-	id: Urbino.Fuchsia,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/5Vbc3mYw8KJtTDC.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/4UIkVEQ1C6tounx.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/tkQ3jlHGeRTDPyn.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/5ZCmFuQhoP3zYnV.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/rOxFKuLX7e5QWhw.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/PxS2mWOR6TILZF9.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/TU81atfzDKiRV2o.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/4UIkVEQ1C6tounx.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/tkQ3jlHGeRTDPyn.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/5ZCmFuQhoP3zYnV.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/rOxFKuLX7e5QWhw.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/PxS2mWOR6TILZF9.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-}
+  faction: factions.Urbino,
+  id: Urbino.Fuchsia,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/5Vbc3mYw8KJtTDC.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/4UIkVEQ1C6tounx.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/tkQ3jlHGeRTDPyn.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/5ZCmFuQhoP3zYnV.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/rOxFKuLX7e5QWhw.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/PxS2mWOR6TILZF9.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/TU81atfzDKiRV2o.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/4UIkVEQ1C6tounx.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/tkQ3jlHGeRTDPyn.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/5ZCmFuQhoP3zYnV.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/rOxFKuLX7e5QWhw.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/PxS2mWOR6TILZF9.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/Urbino/Galatea.tsx
+++ b/src/data/characters/Urbino/Galatea.tsx
@@ -1,70 +1,69 @@
-import { characterData } from "../characterRegistry";
-import { factions, Urbino } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, Urbino } from '../factions';
 
 const character: characterData = {
-	faction: factions.Urbino,
-	id: Urbino.Galatea,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/wpBbSjafRNFD43K.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/n3XUCkglqNYsyJP.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/UQVBxmGPD9q1tsr.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/VmDbBPl9ezv5ZgU.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/xGpjiLgcUtTJbno.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/bNl54Ze1D7wWkJH.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/t1vlASe5DNRHVZq.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/n3XUCkglqNYsyJP.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/UQVBxmGPD9q1tsr.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/VmDbBPl9ezv5ZgU.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/xGpjiLgcUtTJbno.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/bNl54Ze1D7wWkJH.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-}
+  faction: factions.Urbino,
+  id: Urbino.Galatea,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/wpBbSjafRNFD43K.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/n3XUCkglqNYsyJP.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/UQVBxmGPD9q1tsr.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/VmDbBPl9ezv5ZgU.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/xGpjiLgcUtTJbno.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/bNl54Ze1D7wWkJH.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/t1vlASe5DNRHVZq.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/n3XUCkglqNYsyJP.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/UQVBxmGPD9q1tsr.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/VmDbBPl9ezv5ZgU.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/xGpjiLgcUtTJbno.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/bNl54Ze1D7wWkJH.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/Urbino/Maddelena.tsx
+++ b/src/data/characters/Urbino/Maddelena.tsx
@@ -1,70 +1,69 @@
-import { characterData } from "../characterRegistry";
-import { factions, Urbino } from "../factions";
-
+import { characterData } from '../characterRegistry';
+import { factions, Urbino } from '../factions';
 
 const character: characterData = {
-	faction: factions.Urbino,
-	id: Urbino.Maddelena,
-	attack: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/OGgXKe6pPERflQL.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/3djgpfyBbxWzUAD.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/2r7wkizoLbpqMOZ.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/q61FltINbyrA8YV.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/tazvXEJNs5HuyeD.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/yerm1tuq97ZnaWp.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-	defense: {
-		canvasImage: 'https://s2.loli.net/2024/09/29/dxqSrs3ivIJlF5h.png',
-		bodyImage: 'https://cdn.sa.net/2025/04/22/3djgpfyBbxWzUAD.png',
-		skills: {
-			active: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/2r7wkizoLbpqMOZ.png',
-				generateOnCanvas: active
-			},
-			passive: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/q61FltINbyrA8YV.png',
-				generateOnCanvas: passive
-			},
-			ultimate: {
-				skillIcon: 'https://s2.loli.net/2024/09/25/tazvXEJNs5HuyeD.png',
-				generateOnCanvas: ultimate
-			},
-			sub: {
-				skillIcon: 'https://cdn.sa.net/2024/11/19/yerm1tuq97ZnaWp.png',
-				generateOnCanvas: sub
-			}
-		}
-	},
-}
+  faction: factions.Urbino,
+  id: Urbino.Maddelena,
+  attack: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/OGgXKe6pPERflQL.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/3djgpfyBbxWzUAD.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/2r7wkizoLbpqMOZ.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/q61FltINbyrA8YV.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/tazvXEJNs5HuyeD.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/yerm1tuq97ZnaWp.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/dxqSrs3ivIJlF5h.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/3djgpfyBbxWzUAD.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/2r7wkizoLbpqMOZ.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/q61FltINbyrA8YV.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/tazvXEJNs5HuyeD.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/yerm1tuq97ZnaWp.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
 
 function active() {
-	return;
+  return;
 }
 
 function passive() {
-	return;
+  return;
 }
 
 function ultimate() {
-	return;
+  return;
 }
 
 function sub() {
-	return;
+  return;
 }
 
 export default character;

--- a/src/data/characters/characterRegistry.ts
+++ b/src/data/characters/characterRegistry.ts
@@ -1,66 +1,72 @@
-import { factions, PUS, TheScissors, Urbino } from "./factions";
+import { factions, PUS, TheScissors, Urbino } from './factions';
 
 export interface characterRegistry {
-	[key: string]: characterData
+  [key: string]: characterData;
 }
 
 const characterRegistry: characterRegistry = {};
 
 export function registerCharacter(character: characterData) {
-	characterRegistry[character.id] = character;
+  characterRegistry[character.id] = character;
 }
 
 export async function loadAllCharacters() {
-	const factionEnums = {
-		[factions.PUS]: PUS,
-		[factions.TheScissors]: TheScissors,
-		[factions.Urbino]: Urbino
-	};
+  const factionEnums = {
+    [factions.PUS]: PUS,
+    [factions.TheScissors]: TheScissors,
+    [factions.Urbino]: Urbino,
+  };
 
-	for (const faction of Object.keys(factionEnums)) {
-		for (const characterName of Object.keys(factionEnums[faction as factions])) {
-			try {
-				const characterModule = await import(`./${faction}/${characterName}.tsx`);
-				const character: characterData = characterModule.default;
-				registerCharacter(character);
-			} catch (error) {
-				console.error(`Failed to load character: ${characterName} from faction: ${faction}`, error);
-			}
-		}
-	}
+  for (const faction of Object.keys(factionEnums)) {
+    for (const characterName of Object.keys(
+      factionEnums[faction as factions],
+    )) {
+      try {
+        const characterModule = await import(
+          `./${faction}/${characterName}.tsx`
+        );
+        const character: characterData = characterModule.default;
+        registerCharacter(character);
+      } catch (error) {
+        console.error(
+          `Failed to load character: ${characterName} from faction: ${faction}`,
+          error,
+        );
+      }
+    }
+  }
 
-	return characterRegistry;
+  return characterRegistry;
 }
 
 export default characterRegistry;
 
 export interface sideData {
-	canvasImage: string;
-	bodyImage: string;
-	skills: {
-		passive: {
-			skillIcon: string;
-			generateOnCanvas: () => void;
-		},
-		active: {
-			skillIcon: string;
-			generateOnCanvas: () => void;
-
-		},
-		ultimate: {
-			skillIcon: string;
-			generateOnCanvas: () => void;
-		}
-		sub: {
-			skillIcon: string;
-			generateOnCanvas: () => void;
-		}
-	}
+  canvasImage: string;
+  bodyImage: string;
+  skills: {
+    passive: {
+      skillIcon: string;
+      generateOnCanvas: () => void;
+    };
+    active: {
+      skillIcon: string;
+      generateOnCanvas: () => void;
+    };
+    ultimate: {
+      skillIcon: string;
+      generateOnCanvas: () => void;
+    };
+    sub: {
+      skillIcon: string;
+      generateOnCanvas: () => void;
+    };
+  };
 }
 
 export type characterData = {
-	faction: factions;
-	id: PUS | TheScissors | Urbino;
-	attack?: sideData
-	defense?: sideData
-}
+  faction: factions;
+  id: PUS | TheScissors | Urbino;
+  attack?: sideData;
+  defense?: sideData;
+};

--- a/src/data/characters/factions.ts
+++ b/src/data/characters/factions.ts
@@ -1,57 +1,57 @@
 export enum factions {
-	PUS = "PUS",
-	TheScissors = "TheScissors",
-	Urbino = "Urbino"
+  PUS = 'PUS',
+  TheScissors = 'TheScissors',
+  Urbino = 'Urbino',
 }
 
 export enum PUS {
-	Michele = "Michele",
-	Nobunaga = "Nobunaga",
-	Kokona = "Kokona",
-	Yvette = "Yvette",
-	Flavia = "Flavia",
-	Yugiri = "Yugiri",
-	Leona = "Leona"
+  Michele = 'Michele',
+  Nobunaga = 'Nobunaga',
+  Kokona = 'Kokona',
+  Yvette = 'Yvette',
+  Flavia = 'Flavia',
+  Yugiri = 'Yugiri',
+  Leona = 'Leona',
 }
 
 export enum TheScissors {
-	Ming = "Ming",
-	Lawine = "Lawine",
-	Meredith = "Meredith",
-	Reiichi = "Reiichi",
-	Kanami = "Kanami",
-	Eika = "Eika",
-	Fragrans = "Fragrans",
-	Mara = "Mara"
+  Ming = 'Ming',
+  Lawine = 'Lawine',
+  Meredith = 'Meredith',
+  Reiichi = 'Reiichi',
+  Kanami = 'Kanami',
+  Eika = 'Eika',
+  Fragrans = 'Fragrans',
+  Mara = 'Mara',
 }
 
 export enum Urbino {
-	Celestia = "Celestia",
-	Audrey = "Audrey",
-	Maddelena = "Maddelena",
-	Fuchsia = "Fuchsia",
-	BaiMo = "BaiMo",
-	Galatea = "Galatea"
+  Celestia = 'Celestia',
+  Audrey = 'Audrey',
+  Maddelena = 'Maddelena',
+  Fuchsia = 'Fuchsia',
+  BaiMo = 'BaiMo',
+  Galatea = 'Galatea',
 }
 
 type factionData = {
-	[key in factions]: {
-		faction: factions;
-		previewImage: string;
-	}
-}
+  [key in factions]: {
+    faction: factions;
+    previewImage: string;
+  };
+};
 
 export const factionsData: factionData = {
-	PUS: {
-		faction: factions.PUS,
-		previewImage: "https://s2.loli.net/2024/09/25/1El6anYx4qhPbo2.png"
-	},
-	TheScissors: {
-		faction: factions.TheScissors,
-		previewImage: "https://s2.loli.net/2024/09/25/PY4HMU7fbQ32Dr1.png"
-	},
-	Urbino: {
-		faction: factions.Urbino,
-		previewImage: "https://s2.loli.net/2024/09/25/hyPUcLZdMNaeOjI.png"
-	}
-}
+  PUS: {
+    faction: factions.PUS,
+    previewImage: 'https://s2.loli.net/2024/09/25/1El6anYx4qhPbo2.png',
+  },
+  TheScissors: {
+    faction: factions.TheScissors,
+    previewImage: 'https://s2.loli.net/2024/09/25/PY4HMU7fbQ32Dr1.png',
+  },
+  Urbino: {
+    faction: factions.Urbino,
+    previewImage: 'https://s2.loli.net/2024/09/25/hyPUcLZdMNaeOjI.png',
+  },
+};

--- a/src/data/dragAndDrop.ts
+++ b/src/data/dragAndDrop.ts
@@ -1,21 +1,27 @@
-let value: any
+let value: any;
 
 export const getDragValue = () => {
-  return value
-}
+  return value;
+};
 
 export const setDragValue = (ref: any) => {
-  value = ref
-}
+  value = ref;
+};
 
 document.body.addEventListener('touchend', (e) => {
-  const currentDragValue = getDragValue()
-  if (!currentDragValue) return
-  const touchElements = document.elementsFromPoint(e.changedTouches[0].clientX, e.changedTouches[0].clientY)
-  const target = touchElements[1]
+  const currentDragValue = getDragValue();
+  if (!currentDragValue) return;
+  const touchElements = document.elementsFromPoint(
+    e.changedTouches[0].clientX,
+    e.changedTouches[0].clientY,
+  );
+  const target = touchElements[1];
   if (target && target.className == 'pikaso') {
-    const EventClass = e.constructor as new (type: string, event: Event) => Event
-    const eventClone = new EventClass(e.type, e)
-    target.dispatchEvent(eventClone)
+    const EventClass = e.constructor as new (
+      type: string,
+      event: Event,
+    ) => Event;
+    const eventClone = new EventClass(e.type, e);
+    target.dispatchEvent(eventClone);
   }
-})
+});

--- a/src/data/grenades.ts
+++ b/src/data/grenades.ts
@@ -1,110 +1,106 @@
-
 export enum grenades {
-	Flashbang = "Flashbang",
-	FragGrenade = "FragGrenade",
-	HealingGrenade = "HealingGrenade",
-	Interceptor = "Interceptor",
-	SlowGrenade = "SlowGrenade",
-	SmokeBomb = "SmokeBomb",
-	Alarm = "Alarm",
-	WindstormGrenade = "WindstormGrenade",
-	SnowBall = "SnowBall"
+  Flashbang = 'Flashbang',
+  FragGrenade = 'FragGrenade',
+  HealingGrenade = 'HealingGrenade',
+  Interceptor = 'Interceptor',
+  SlowGrenade = 'SlowGrenade',
+  SmokeBomb = 'SmokeBomb',
+  Alarm = 'Alarm',
+  WindstormGrenade = 'WindstormGrenade',
+  SnowBall = 'SnowBall',
 }
 
 export interface grenadeData {
-	grenade: grenades;
-	imageLink: string;
+  grenade: grenades;
+  imageLink: string;
 }
 
 export const grenadeData: grenadeData[] = [
-	{
-		grenade: grenades.SmokeBomb,
-		imageLink: "https://cdn.sa.net/2025/04/22/4HUeCu6j3KdzfFy.png"
-	},
-	{
-		grenade: grenades.SnowBall,
-		imageLink: "https://s2.loli.net/2024/09/24/siyl1V9OETwdntX.png"
-	},
-	{
-		grenade: grenades.Alarm,
-		imageLink: "https://cdn.sa.net/2025/04/22/w3ufEYUP89tlJq4.png"
-	},
-	{
-		grenade: grenades.SlowGrenade,
-		imageLink: "https://cdn.sa.net/2025/04/22/t42oXRpBiEDYFWq.png"
-	},
-	{
-		grenade: grenades.HealingGrenade,
-		imageLink: "https://cdn.sa.net/2025/04/22/X2MtclAev6NERfa.png"
-	},
-	{
-		grenade: grenades.FragGrenade,
-		imageLink: "https://cdn.sa.net/2025/04/22/dFuTREQAbfCGY9p.png"
-	},
-	{
-		grenade: grenades.Flashbang,
-		imageLink: "https://cdn.sa.net/2025/04/22/JTyFboHSYk7Dd94.png"
-	},
-	{
-		grenade: grenades.WindstormGrenade,
-		imageLink: "https://cdn.sa.net/2025/04/22/xPqkuA3wTUyGStV.png"
-	},
-	{
-		grenade: grenades.Interceptor,
-		imageLink: "https://cdn.sa.net/2025/04/22/b8jqTHJZxtEPgy5.png"
-	}
-]
-
-
-
+  {
+    grenade: grenades.SmokeBomb,
+    imageLink: 'https://cdn.sa.net/2025/04/22/4HUeCu6j3KdzfFy.png',
+  },
+  {
+    grenade: grenades.SnowBall,
+    imageLink: 'https://s2.loli.net/2024/09/24/siyl1V9OETwdntX.png',
+  },
+  {
+    grenade: grenades.Alarm,
+    imageLink: 'https://cdn.sa.net/2025/04/22/w3ufEYUP89tlJq4.png',
+  },
+  {
+    grenade: grenades.SlowGrenade,
+    imageLink: 'https://cdn.sa.net/2025/04/22/t42oXRpBiEDYFWq.png',
+  },
+  {
+    grenade: grenades.HealingGrenade,
+    imageLink: 'https://cdn.sa.net/2025/04/22/X2MtclAev6NERfa.png',
+  },
+  {
+    grenade: grenades.FragGrenade,
+    imageLink: 'https://cdn.sa.net/2025/04/22/dFuTREQAbfCGY9p.png',
+  },
+  {
+    grenade: grenades.Flashbang,
+    imageLink: 'https://cdn.sa.net/2025/04/22/JTyFboHSYk7Dd94.png',
+  },
+  {
+    grenade: grenades.WindstormGrenade,
+    imageLink: 'https://cdn.sa.net/2025/04/22/xPqkuA3wTUyGStV.png',
+  },
+  {
+    grenade: grenades.Interceptor,
+    imageLink: 'https://cdn.sa.net/2025/04/22/b8jqTHJZxtEPgy5.png',
+  },
+];
 
 export enum others {
-	Bomb = "Bomb",
-	BombA = "BombA",
-	BombB = "BombB",
-	BombC = "BombC",
-	Focus = "Focus",
-	Warning = "Warning",
-	Flag = "Flag",
-	Danger = "Danger",
+  Bomb = 'Bomb',
+  BombA = 'BombA',
+  BombB = 'BombB',
+  BombC = 'BombC',
+  Focus = 'Focus',
+  Warning = 'Warning',
+  Flag = 'Flag',
+  Danger = 'Danger',
 }
 
 export interface otherData {
-	other: others;
-	imageLink: string;
+  other: others;
+  imageLink: string;
 }
 
 export const otherData: otherData[] = [
-	{
-		other: others.Bomb,
-		imageLink: "https://cdn.sa.net/2025/02/15/lvcYUqwA7rMsfEu.png"
-	},
-	{
-		other: others.BombA,
-		imageLink: "https://cdn.sa.net/2025/02/15/1jothFAux6P95Ve.png"
-	},
-	{
-		other: others.BombB,
-		imageLink: "https://cdn.sa.net/2025/02/15/TvUCl3QqiFyKj2r.png"
-	},
-	{
-		other: others.BombC,
-		imageLink: "https://cdn.sa.net/2025/02/15/6NUMSbevIiap534.png"
-	},
-	{
-		other: others.Focus,
-		imageLink: "https://cdn.sa.net/2025/02/15/SeVw3s7OgrbyaCz.png"
-	},
-	{
-		other: others.Warning,
-		imageLink: "https://cdn.sa.net/2025/02/15/7Ev1A5tIfQgiJLl.png"
-	},
-	{
-		other: others.Flag,
-		imageLink: "https://cdn.sa.net/2025/02/15/Yr62e537ER4Musv.png"
-	},
-	{
-		other: others.Danger,
-		imageLink: "https://cdn.sa.net/2025/02/15/M1RvciEu7AwTpnt.png"
-	},
-]
+  {
+    other: others.Bomb,
+    imageLink: 'https://cdn.sa.net/2025/02/15/lvcYUqwA7rMsfEu.png',
+  },
+  {
+    other: others.BombA,
+    imageLink: 'https://cdn.sa.net/2025/02/15/1jothFAux6P95Ve.png',
+  },
+  {
+    other: others.BombB,
+    imageLink: 'https://cdn.sa.net/2025/02/15/TvUCl3QqiFyKj2r.png',
+  },
+  {
+    other: others.BombC,
+    imageLink: 'https://cdn.sa.net/2025/02/15/6NUMSbevIiap534.png',
+  },
+  {
+    other: others.Focus,
+    imageLink: 'https://cdn.sa.net/2025/02/15/SeVw3s7OgrbyaCz.png',
+  },
+  {
+    other: others.Warning,
+    imageLink: 'https://cdn.sa.net/2025/02/15/7Ev1A5tIfQgiJLl.png',
+  },
+  {
+    other: others.Flag,
+    imageLink: 'https://cdn.sa.net/2025/02/15/Yr62e537ER4Musv.png',
+  },
+  {
+    other: others.Danger,
+    imageLink: 'https://cdn.sa.net/2025/02/15/M1RvciEu7AwTpnt.png',
+  },
+];

--- a/src/data/i18n.tsx
+++ b/src/data/i18n.tsx
@@ -4,9 +4,9 @@ import ja_JP from './languages/ja_JP';
 import zh_CN from './languages/zh_CN';
 
 export const i18nData: {
-  [key in Languages]: I18nData
+  [key in Languages]: I18nData;
 } = {
   English: en_US,
   日本語: ja_JP,
-  简体中文: zh_CN
-}
+  简体中文: zh_CN,
+};

--- a/src/data/languages/en_US.tsx
+++ b/src/data/languages/en_US.tsx
@@ -1,503 +1,593 @@
-import { FaGithub } from "react-icons/fa";
-import { Languages } from "../../types/interface";
+import { FaGithub } from 'react-icons/fa';
+import { Languages } from '../../types/interface';
 
 export default {
-	language: Languages.en_US,
-	title: 'Strinova Map Assistant',
-	announcement: "Announcement",
-	friendlink: "Friend Link",
-	sitelist: "Switch Server",
-	announcementdata: {
-		notshowntoday: "Got it",
-		pin: {
-			title: "Update",
-			date: "2025.4.23",
-			summary: "New Map & New Agent added.",
-			data: {}
-		},
-		history: []
-	},
-	friendlinkdata: {
-		classify: {
-			official: "Official",
-			wiki: "Wiki",
-			others: "Others"
-		},
-		official:
-			[{
-				name: "",
-				icon: <img style={{ height: "35px", filter: "brightness(1000%) drop-shadow(0 0 2px rgba(var(--semi-grey-7))" }} src='https://game.gtimg.cn/images/kq/m/web20230505/sec_ordlogo.png' />,
-				url: "https://klbq.qq.com/",
-			}, {
-				name: "",
-				icon: <img style={{ height: "22px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-9))" }} src='https://klbq-web-cms.strinova.com/prod/strinova_static/home_v12/img/icon/logo-white.png' />,
-				url: "https://www.strinova.com/",
-			}],
-		wiki:
-			[{
-				name: "",
-				icon: <img style={{ height: "32px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-9))" }} src='https://s2.loli.net/2024/10/01/NQTMvDZ5ah4omYR.png' />,
-				url: "https://wiki.biligame.com/klbq/",
-			}, {
-				name: "Strinovajp Wiki",
-				icon: <></>,
-				url: "https://www.strinovajp-wiki.jp/index.html",
-			}, {
-				name: "",
-				icon: <img style={{ height: "22px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))" }} src='https://s2.loli.net/2024/10/01/R4UxmBPGd2f8kQ7.webp' />,
-				url: "https://strinova.wiki.gg/wiki/Strinova_Wiki",
-			}, {
-				name: "Miraheze Meta",
-				icon: <></>,
-				url: "https://strinova.org/wiki/",
-			}, {
-				name: "日本語wiki",
-				icon: <img style={{ height: "28px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))", marginRight: "8px" }} src='https://w.atwiki.jp/common/_img/atwiki_logo_small.svg?t=741a51e81c8c8d5fe9627b874ecad193' />,
-				url: "https://w.atwiki.jp/calabiyau_jp/",
-			},],
-		others:
-			[{
-				name: "自建房助手",
-				icon: <img style={{ height: "35px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))", marginRight: "8px" }} src='https://s2.loli.net/2024/10/01/pmYnw16rL2PQWBy.png' />,
-				url: "https://klbq.fsltech.cn/",
-			}],
-		contact: {
-			content: <div style={{ width: "100%", textAlign: "center" }}>
-				Add friend link contact <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
-			</div>
-		}
-	},
-	sitelistdata: {
-		content: <>
-			<div>We set several sites for better connection.</div>
-		</>,
-		Global: [
-			{
-				icon: <><FaGithub style={{ color: "rgba(var(--semi-grey-9), 1)", fontSize: "20px", marginRight: "10px" }} /></>,
-				content: "Github Page",
-				url: "https://strinova.fsltech.cn/"
-			}
-		],
-		CN: [],
-	},
-	supportusdata: {
-		content: <>
-			<div><strong>STRINOVA MAP ASSISTANT</strong>is an open-source React project.</div>
-			<div>So you can use it freely under license GPL-3.0.</div>
-			<div>Some image source may need further permission.</div>
-			<div>Please ask the official.</div>
-			<br />
-			<div>Even thougth, you can donate to the developers to make this project better.</div>
-			<div>Whatever support you gave ,your would be listed on <strong>STRINOVA MAP ASSISTANT</strong>'s namelist.</div>
-			<div>Contact <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a> if you have any more requests.</div>
-		</>,
-		global: "International",
-		CN: "CN",
-		list: "Support List"
-	},
-	sidebar: {
-		attact: 'Attack',
-		defense: 'Defense',
-		mapsetting: 'Map Setting',
-		character: 'Character',
-		skill: 'Skills',
-		grenade: 'Grenades',
-		other: 'Others',
-		lineup: 'Grenade Lineups',
-		skilllineup: 'Skill Lineups',
-		mobaisuperjump: 'Baimo Super Jumps',
-		bugpoint: 'Bugs',
-		bugpointwarning: (
-			<div style={{ fontSize: '12px', textAlign: 'left' }}>
-				<div>Bugs listed here are for your information only!</div>
-				<div>We are not responsible for any bans for abusing any of these bugs.</div>
-			</div>
-		),
-		learnmore: 'Learn More',
-		supportus: 'SUPPORT US',
-		supportusContent: <></>
-	},
-	mapsetting: {
-		choosemap: 'Map',
-		maps: {
-			WindyTown: 'Windy Town',
-			SpaceLab: 'Space Lab',
-			Khesmet: 'Khesmet',
-			CauchyDistrict: 'Cauchy District',
-			EulerPort: 'Port Euler',
-			Area88: 'Area 88',
-			Base404: 'Base 404',
-			Ocarnus: 'Ocarnus'
-		},
-		TeamHighlight: 'Team Highlight',
-		TeamHighlightOptions: {
-			prepare: 'Show',
-			blank: 'Hide'
-		},
-		Landmarks: 'Landmarks'
-	},
-	lineupsetting: {
-		spotmark: 'Spot Mark',
-		spotmarks: {
-			disable: 'Disable',
-			available: 'Available Only',
-			all: 'All'
-		}
-	},
-	skilllineupsetting: {
-		spotmark: 'Spot Mark',
-		spotmarks: {
-			disable: 'Disable',
-			available: 'Available Only',
-			all: 'All'
-		}
-	},
-	mobaisuperjumpsetting: {
-		spotmark: 'Spot Mark',
-		spotmarks: {
-			disable: 'Disable',
-			available: 'Available Only',
-			all: 'All'
-		}
-	},
-	bugpointsetting: {
-		spotmark: 'Spot Mark',
-		spotmarks: {
-			disable: 'Disable',
-			available: 'Available Only',
-			all: 'All'
-		}
-	},
-	factions: {
-		PUS: 'PUS',
-		TheScissors: 'The Scissors',
-		Urbino: 'Urbino'
-	},
-	characters: {
-		PUS: {
-			Michele: 'Michele Li',
-			Nobunaga: 'Nobunaga',
-			Kokona: 'Kokona',
-			Yvette: 'Yvette',
-			Flavia: 'Flavia',
-			Yugiri: "Yugiri",
-			Leona: "Leona"
-		},
-		TheScissors: {
-			Ming: 'Ming',
-			Lawine: 'Lawine',
-			Meredith: 'Meredith',
-			Reiichi: 'Reiichi',
-			Kanami: 'Kanami',
-			Eika: 'Eika',
-			Fragrans: 'Fragrans',
-			Mara: 'Mara'
-		},
-		Urbino: {
-			Celestia: 'Celestia',
-			Audrey: 'Audrey',
-			Maddelena: 'Maddelena',
-			Fuchsia: 'Fuchsia',
-			BaiMo: 'Bai Mo',
-			Galatea: 'Galatea'
-		}
-	},
-	characterInfo: {
-		Michele: {
-			Name: "Michele",
-			Type: "Sentinel",
-			skillActiveName: `Meow Meow! Turret`,
-			skillActiveDescription: `Michele throws a small turret that attached to any surface (except player). The turret will automaticaly attack enemy (3 dmg/s) and slow them down.`,
-			skillPassiveName: `Cat Sense`,
-			skillPassiveDescription: `Enemy that damaged Michele will be highlighted for Michele and her teammates.`,
-			skillUltimateName: `Ultra! Meow Meow!`,
-			skillUltimateDescription: `Michele deploy a big Meow Meow Drone with powerful firepower. It will automaticaly attack enemy with bigger damage & range.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Nobunaga: {
-			Name: "Nobunaga",
-			Type: "Sentinel",
-			skillActiveName: `Observer`,
-			skillActiveDescription: `Nobunaga place a device on the ground which will gains Rate Of Fire, faster reload & restore Armor when he's within it range. Max 2 charges. If 2 Observer are placed within each other range, the buff effects are increased. It can be destroyed.`,
-			skillPassiveName: `Blinding Pulse`,
-			skillPassiveDescription: `When ADS, Nobunaga will build energy with his rifle. When fully charged, if enemy got hit by this charged shot, their crosshairs in ADS will be glitched out. Nobunaga's base Armor +10`,
-			skillUltimateName: `E.M.P`,
-			skillUltimateDescription: `Place a pulse device on the ground which emit large range pulse wave. Enemy within range will be highlighted & silenced continuously. It can be detroyed by any weapons.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Kokona: {
-			Name: "Kokona",
-			Type: "Support",
-			skillActiveName: `Healing Drone`,
-			skillActiveDescription: `Kokona sends a healing drone to heal and recover armor a selected ally or herself. Allies that stand near the drone will also healed.`,
-			skillPassiveName: `Emergency Rescue`,
-			skillPassiveDescription: `Kokona can summon a drone to auto-revive downed allies. Can revive multiple allies at the same time. Revived ally has 50 HP. Also Kokona restores 2 HP per second.`,
-			skillUltimateName: `Rebuild`,
-			skillUltimateDescription: `Kokona open up K.I.A terminal and choose an ally to resurrect using drones. The resurected ally will has full HP & Armor. It can be canceled either kill Kokona before she ults or destroy the drones when they resurrecting.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Yvette: {
-			Name: "Yvette",
-			Type: "Controller",
-			skillActiveName: `Fei`,
-			skillActiveDescription: `Yvette summon her teddy bear Fei to tranform into a real bear. Press the skill again to control Fei, Fei can dash forward to knock enemies up & leave an icy ground behind (2 charges). Which makes enemy slides & take more damage. Hold right mouse to recall Fei. Yvette is vulnerable while controlling Fei.`,
-			skillPassiveName: `Hidden Snow`,
-			skillPassiveDescription: `Yvette will go stealth after standing still for few secs. She can only be detected if going near her stealth range.`,
-			skillUltimateName: `Cold Breeze`,
-			skillUltimateDescription: `Yvette summon raging Fei that that slam the ground 3 times & create an icy ground which get bigger each slam. Enemy inside will slides, take more damage, slower Reload Speed, slower ADS Speed & slower Rate Of Fire.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Flavia: {
-			Name: "Flavia",
-			Type: "Duellist",
-			skillActiveName: `Illusory Phantom`,
-			skillActiveDescription: `Flavia summons the Phantom Butterfly to follows her for 5 seconds, during which time she loses 1HP from an attack, she becomes invincible for 2 seconds and spawns a Phantom Orb on the spot. The Phantom Orb will near-sight surrounding enemies and can be destroyed. Use the skill again to cancel invincible state instantly.`,
-			skillPassiveName: `Rebirth Circle`,
-			skillPassiveDescription: `Whenever Flavia takes 15 Damage, reduces Illusory Phantom's cooldown by 1 second. For every 160 damage taken, she gains 1 temporary Ultimate Point, which remains valid for the current round. Flavia's base armor +5'`,
-			skillUltimateName: `Dream Butterfly Transformation`,
-			skillUltimateDescription: `Flavia creates an illusionary field centered around herself. If she knocked out while in the field, Flavia'll transforms into a butterfly & revives herself after 3 seconds (repeat till ult ends). Enemies outside the field cannot see Flavia but they still can attack Flavia & will see Flavia if they attacked by her. If Flavia is killed by enemies outside the field, it will not trigger auto-revive & she'll die instantly.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Yugiri: {
-			Name: "Yugiri",
-			Type: "Controller",
-			skillActiveName: `Poison Mist`,
-			skillActiveDescription: `Throws a snail forward, creating a poisonous mist in a spherical area upon activation. The mist continuously lowers the maximum armour of enemies, which will then recover shortly after leaving the mist. Activating the snail will cost energy, and activating multiple snails will consume more energy then if one is activated. `,
-			skillPassiveName: `Toxic Fog Eruption`,
-			skillPassiveDescription: `After dealing a set amount of HP, she will cause an explosion within the enemy, affecting it with corrosion, temporarily corroding the nearby enemy’s shield. `,
-			skillUltimateName: `Poison Erosion`,
-			skillUltimateDescription: `Summons a large wave of mist that slowly advances forwards, reducing the max shields of any enemy struck and also applying the Corrosion effect. `,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Leona: {
-			Name: "Leona",
-			Type: "Sentinel",
-			skillActiveName: `KINETIC BARRIER`,
-			skillActiveDescription: `Leona generates square blocks with two-angle options on designated surfaces. Generating blocks consumes skill points and energy. Up to 16 blocks can exist at once.`,
-			skillPassiveName: `WORK-LIFE BALANCE`,
-			skillPassiveDescription: `While stringified, Leona continuously regenerates energy. When energy is above 50%, her movement speed increases; if below 50%, her armor gradually recovers.`,
-			skillUltimateName: `FORTRESS OF PURITY`,
-			skillUltimateDescription: `Leona fills her energy bar, making existing and newly generated blocks permanently transparent during the skill duration. Transparent blocks no longer block paths or ally bullets.`,
-			subName: `防弹护窗`,
-			subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
-		},
-		Ming: {
-			Name: "Ming",
-			Type: "Duellist",
-			skillActiveName: `Plasma Ball`,
-			skillActiveDescription: `Fires a ball of electricity that will automatically detonate when it reaches the maximum distance or hits an enemy superstring. It can also be manually detonated by pressing the skill key again. The ball of electricity will destroy the armor of all enemy units (including summons) within the range and slow them down. Ming will increase his movement speed when entering the electric field.`,
-			skillPassiveName: `Armor Absorbing`,
-			skillPassiveDescription: `When Ming uses firearms and active skills to damage the enemy's armor or shield, his armor will be restored based on the amount of damage. During the duration of the ultimate, the passive will restore temporary armor and increase the amount restored.`,
-			skillUltimateName: `Plasma Armor`,
-			skillUltimateDescription: `Ming gains temporary armor and applies a stackable slow to his shots. When Ming uses a gun or active skill to damage an enemy's armor, the skill's duration is extended and temporary armor is restored.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Lawine: {
-			Name: "Lawine",
-			Type: "Initiator",
-			skillActiveName: `Pulse Knife`,
-			skillActiveDescription: `Throws the Pulse Knife to create a large magnetic field, slowly highlight enemies within range to Lawine and her teammates. The pulse knife will disappear immediately after a failed scan. The pulse knife can scan up to 3 times and can be destroyed by any weapons & nades.`,
-			skillPassiveName: `Exposure Trace`,
-			skillPassiveDescription: `Enemy hit by Lawine's Primary Weapon will be highlighted. Only Lawine can see.`,
-			skillUltimateName: `Escape The Shadow`,
-			skillUltimateDescription: `Lawine creates a rectangular magnetic field in front. When entering the magnetic field, Lawine becomes invisible. Lawine cannot use any weapons while invisible.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Meredith: {
-			Name: "Meredith",
-			Type: "Controller",
-			skillActiveName: `Sand Heatwave`,
-			skillActiveDescription: `Meredith fires an energy orb which will creates a sand field when hit enemy or obstacles. All enemy inside will be slowed, reduces reload speed and their HP will reduces overtime.`,
-			skillPassiveName: `Time Warp`,
-			skillPassiveDescription: `Reduce Meredith's falling speed when aiming, using skills and nades.`,
-			skillUltimateName: `Quicksand Burial`,
-			skillUltimateDescription: `Meredith throws a pyramid artifact and create a massive sandstorm. All enemy inside will be near-sighted, HP reduced overtime, slowed down while being pulled to the center. Allies also got near-sighted.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Reiichi: {
-			Name: "Reiichi",
-			Type: "Controller",
-			skillActiveName: `Dawn Curtain`,
-			skillActiveDescription: `Reiichi uses his umbrella to create a curtain of Paper energy light that can be released vertically or horizontally, which obscures the field of view.`,
-			skillPassiveName: `Dawn Insight`,
-			skillPassiveDescription: `When in ADS, Reiichi will build up energy with his sniper. When fully charged, it will scan a small are in front of him & hightlight all enemy for himself & teammates.`,
-			skillUltimateName: `Sacred Screen of Refuge`,
-			skillUltimateDescription: `Immediately refresh Dawn Curtain, and enchance Dawn Curtain which now can block bullets from enemy. The blocking effect also applies to pre-use Dawn Curtain.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Kanami: {
-			Name: "Kanami",
-			Type: "Initiator",
-			skillActiveName: `Symphony`,
-			skillActiveDescription: `Kanami infuses her sniper with her melody, then shoot to any surface which will resonate and hightlight all enemy in it radius for Kanami & teammates.`,
-			skillPassiveName: `Sonic Boom`,
-			skillPassiveDescription: `When a bullet hit a target it will highlight enemy and ultilities through wall briefly.`,
-			skillUltimateName: `Showtime`,
-			skillUltimateDescription: `Kanami summon a hologram of herself, the music start playing which glitch out enemy scope in ADS while slowing & pulling them to the center.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Eika: {
-			Name: "Eika",
-			Type: "Duellist",
-			skillActiveName: `Hellfire Cage`,
-			skillActiveDescription: `Creates a fire cage in front of Aika that burns enemies who pass through its boundaries, and the cage disippates prematurely if there are no more enemies inside. When Aika enters the cage, her shotgun will deals additional burn damage against enemies within the cage. Casting the skill with 100 heat, the flame will turn to blue & enemy takes more damage.`,
-			skillPassiveName: `Reserve Flare`,
-			skillPassiveDescription: `When Aika deals damage to enemies, She gathers a small amount of heat for her heat gauge, up to a max of 100. At max heat, Aika deals bonus damage against paper-mode enemies and empowers her abilities.`,
-			skillUltimateName: `Firestorm`,
-			skillUltimateDescription: `Throws out up to 3 fireball that can explode into a tornado, lifting (like wind bomb effect) and pulling in enemies, dealing continuous fire damage to them. Casting the skill with 100 heat, increases the tornado's size, damage, as well as highlighting (Not through wall) any enemies caught within.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Fragrans: {
-			Name: "Fragrans",
-			Type: "Support",
-			skillActiveName: `Vibrant And Fragrant`,
-			skillActiveDescription: `Fragrans can release two limited quantities of perfumes. After being released, it will create a fragrance area centered on itself, and the area will increase the fire rate or movement speed of the ally, and the fragrance effect will gradually decrease over time, and eventually disappear.`,
-			skillPassiveName: `Revive The Aroma`,
-			skillPassiveDescription: `Fragrans emits a faint scent of recovery, and nearby teammates and herself slowly regenerate health.`,
-			skillUltimateName: `Intense Fragrance`,
-			skillUltimateDescription: `Fragrans will create an area of intense fragrance centered on herself, and allies in the area will gain a high rate of fire, increased movement speed, and health regeneration, the effect will not be decayed, and Fragrans will not be able to use weapons during the release, but will receive a significant damage reduction.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Mara: {
-			Name: "Mara",
-			Type: "Duellist",
-			skillActiveName: `Phantom Grip`,
-			skillActiveDescription: `Mara casts a phantom hand that targets the nearest standing enemy, pulling a Soul Orb from their body and slowing them down. Only Mara can attack the Soul Orb with her weapon. Damaging the Soul Orb partially inflicts armor-ignoring HP damage on the enemy. The Soul Orb shrinks when the enemy sidesteps or glides.`,
-			skillPassiveName: `Soul Reaver`,
-			skillPassiveDescription: `Mara recovers a portion of HP and deals extra armor-ignoring DMG when using her weapon on non-full-HP enemies. This recovery effect also applies to the Soul Orb DMG from her Active Skill.`,
-			skillUltimateName: `Grim Reaper`,
-			skillUltimateDescription: `Mara marks the nearest enemy, applying silence and making them visible only to her. If Mara participates in a knockdown or kill of this target, the mark transfers to the nearest standing enemy within range and resets its duration. The effect lasts until Mara dies or time runs out.`,
-			subName: `-`,
-			subDescription: `-`,
-		},
-		Celestia: {
-			Name: "Celestia",
-			Type: "Support",
-			skillActiveName: `Guardian Of The Star`,
-			skillActiveDescription: `Celestia targets an allied character with a guardian star, replenishing temporary armor. The star then returns to her, granting her the half of the original effect.`,
-			skillPassiveName: `Cosmos`,
-			skillPassiveDescription: `When allies is near Huxing, both allies & herself will regain Armor overtime (+2/s). `,
-			skillUltimateName: `Stargate`,
-			skillUltimateDescription: `Huxing open the Stargate and choose an ally across the map, immediately gains her & the chosen ally a huge Extra Armor, then she'll start build up enegry. When fully charged, Huxing will teleports to the chosen ally. It can be canceled if Huxing takes certain amount of damage or uses the skill again. When canceled Huxing will teleport back to where she used the skill, the Extra Armor Buff will not lost.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Audrey: {
-			Name: "Audrey",
-			Type: "Sentinel",
-			skillActiveName: `Heavy Fire`,
-			skillActiveDescription: `Audrey enters stationary state & cannot move. Greatly increase Rate Of Fire & Max Shield Limit of her MG. Her MG is no longer need to reload but will overheat overtime. Audrey MG no longer has recoil.`,
-			skillPassiveName: `Royal Shield`,
-			skillPassiveDescription: `Audrey will gains 30 Extra Armor when ADS. This Extra Armor will be restored shortly after the shield is broken. Audrey's base armor +5`,
-			skillUltimateName: `Bombardment`,
-			skillUltimateDescription: `Audrey enters stationary state & summon her grenade launcher that shoot out 6 incendiary round. Each round will bounce off the wall and explodes when hit the ground, creating 3 small area of fire causing damage overtime.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Maddelena: {
-			Name: "Maddelena",
-			Type: "Controller",
-			skillActiveName: `Color Binding`,
-			skillActiveDescription: `Maddelena fires a puddle of paint, enemies that pass through this puddle will be slowed and cannot use Paper Mode.`,
-			skillPassiveName: `Color Footprint`,
-			skillPassiveDescription: `Enemy hit by Maddelena' Primary Weapon or her skills will be slowed and leave footprints behind.`,
-			skillUltimateName: `Color Bubble`,
-			skillUltimateDescription: `Maddelena fires a giant bubble which will becomes bigger overtime, enemies within the bubble won't be able to use Paper Mode and leave their footprints. When the bubble explodes, it will apply slow and vulnerability effect to enemies within the blast area.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Fuchsia: {
-			Name: "Fuchsia",
-			Type: "Duellist",
-			skillActiveName: `Predator's Sense`,
-			skillActiveDescription: `Fuchsia senses surrounding enemies which highlights full HP enemies briefly & continiously for injured enemies. Sensing enemy will also increase Fuchsia's movement speed for short time.`,
-			skillPassiveName: `Fight To Feed`,
-			skillPassiveDescription: `When Fuchsia get a kill or assist, dead enemy will drop an Energy Crystal. She can go near and absorb it which will quickly restores herself 50HP.`,
-			skillUltimateName: `Bloodbath`,
-			skillUltimateDescription: `Fuchsia gains massive Rate Of Fire, faster Reload Speed, ADS Speed & Movement Speed. Predator's Sense will be enchanced & hightlight all enemies in her view. Absorbing Energy Crystal will extend the duration.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		BaiMo: {
-			Name: "BaiMo",
-			Type: "Duellist",
-			skillActiveName: `Skydance`,
-			skillActiveDescription: `Baimo quickly dash forward & immediately reload 2 shell to his shotgun. Getting a kill will refresh the skill.`,
-			skillPassiveName: `Hip-Hop Boom Color`,
-			skillPassiveDescription: `When BaiMo deals atleast 50 Damage to enemy, they Paper Mode is disabled for few secs.`,
-			skillUltimateName: `Let's Rock!`,
-			skillUltimateDescription: `BaiMo place a respawn beacon at selected area and the music starts playing. When killed or press the skill again, Baimo will teleport back to the beacon fully restore his HP.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Galatea: {
-			Name: "Galatea",
-			Type: "Initiator",
-			skillActiveName: `Flying Cards Flash`,
-			skillActiveDescription: `Galatea releases a card that flies out in an arc, and when the card touches the ground or wall, a clone will be generated, and Galatea can teleport to the location of the clone by pressing the interaction button, and the clone can be destroyed. Each clone can detect visible enemies within a 10-meter radius and expose them to Galatea and all of her teammates, as well as enemies attacking the clone for a short period of time`,
-			skillPassiveName: `Fraudulent Shadow`,
-			skillPassiveDescription: `When Galatea detaches from a wall, it leaves a clone at the wall sticker, and each time she gets off the wall, it will respawn again, and when the clone is damaged, it will passively enter the cooldown.`,
-			skillUltimateName: `Shadow Card Trick`,
-			skillUltimateDescription: `Galatea throws a bunch of cards in front of her, each of which spawns a clone and teleports Galatea.`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		}
-	},
-	characterTypes: {
-		Sentinel: 'Sentinel',
-		Support: 'Support',
-		Controller: 'Controller',
-		Duellist: 'Duellist',
-		Initiator: 'Initiator'
-	},
-	grenades: {
-		Flashbang: 'Flashbang',
-		FragGrenade: 'Frag Grenade',
-		HealingGrenade: 'Healing Grenade',
-		Interceptor: 'Interceptor',
-		SlowGrenade: 'Slow Grenade',
-		SmokeBomb: 'Smoke Bomb',
-		Alarm: 'Alarm',
-		WindstormGrenade: 'Windstorm Grenade',
-		SnowBall: 'Snow Ball'
-	},
-	others: {
-		Bomb: 'Bomb',
-		BombA: 'Bomb A',
-		BombB: 'Bomb B',
-		BombC: 'Bomb C',
-		Focus: 'Focus',
-		Warning: 'Warning',
-		Flag: 'Flag',
-		Danger: 'Danger',
-	},
-	markbox: {
-		mark: 'Mark',
-		straightline: 'Straight Line',
-		arrowline: 'Arrow Line',
-		color: 'Color',
-		undo: 'Undo',
-		clear: 'Clear',
-		clearwarning: {
-			title: 'Confirm to clear all marks?',
-			content: 'This action cannot be undone',
-			ok: 'Confirm',
-			cancel: 'Cancel',
-			success: 'Cleared all markings',
-			failure: 'Failed to clear markings'
-		}
-	}
-}
+  language: Languages.en_US,
+  title: 'Strinova Map Assistant',
+  announcement: 'Announcement',
+  friendlink: 'Friend Link',
+  sitelist: 'Switch Server',
+  announcementdata: {
+    notshowntoday: 'Got it',
+    pin: {
+      title: 'Update',
+      date: '2025.4.23',
+      summary: 'New Map & New Agent added.',
+      data: {},
+    },
+    history: [],
+  },
+  friendlinkdata: {
+    classify: {
+      official: 'Official',
+      wiki: 'Wiki',
+      others: 'Others',
+    },
+    official: [
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '35px',
+              filter:
+                'brightness(1000%) drop-shadow(0 0 2px rgba(var(--semi-grey-7))',
+            }}
+            src='https://game.gtimg.cn/images/kq/m/web20230505/sec_ordlogo.png'
+          />
+        ),
+        url: 'https://klbq.qq.com/',
+      },
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '22px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-9))',
+            }}
+            src='https://klbq-web-cms.strinova.com/prod/strinova_static/home_v12/img/icon/logo-white.png'
+          />
+        ),
+        url: 'https://www.strinova.com/',
+      },
+    ],
+    wiki: [
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '32px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-9))',
+            }}
+            src='https://s2.loli.net/2024/10/01/NQTMvDZ5ah4omYR.png'
+          />
+        ),
+        url: 'https://wiki.biligame.com/klbq/',
+      },
+      {
+        name: 'Strinovajp Wiki',
+        icon: <></>,
+        url: 'https://www.strinovajp-wiki.jp/index.html',
+      },
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '22px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+            }}
+            src='https://s2.loli.net/2024/10/01/R4UxmBPGd2f8kQ7.webp'
+          />
+        ),
+        url: 'https://strinova.wiki.gg/wiki/Strinova_Wiki',
+      },
+      {
+        name: 'Miraheze Meta',
+        icon: <></>,
+        url: 'https://strinova.org/wiki/',
+      },
+      {
+        name: '日本語wiki',
+        icon: (
+          <img
+            style={{
+              height: '28px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+              marginRight: '8px',
+            }}
+            src='https://w.atwiki.jp/common/_img/atwiki_logo_small.svg?t=741a51e81c8c8d5fe9627b874ecad193'
+          />
+        ),
+        url: 'https://w.atwiki.jp/calabiyau_jp/',
+      },
+    ],
+    others: [
+      {
+        name: '自建房助手',
+        icon: (
+          <img
+            style={{
+              height: '35px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+              marginRight: '8px',
+            }}
+            src='https://s2.loli.net/2024/10/01/pmYnw16rL2PQWBy.png'
+          />
+        ),
+        url: 'https://klbq.fsltech.cn/',
+      },
+    ],
+    contact: {
+      content: (
+        <div style={{ width: '100%', textAlign: 'center' }}>
+          Add friend link contact{' '}
+          <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
+        </div>
+      ),
+    },
+  },
+  sitelistdata: {
+    content: (
+      <>
+        <div>We set several sites for better connection.</div>
+      </>
+    ),
+    Global: [
+      {
+        icon: (
+          <>
+            <FaGithub
+              style={{
+                color: 'rgba(var(--semi-grey-9), 1)',
+                fontSize: '20px',
+                marginRight: '10px',
+              }}
+            />
+          </>
+        ),
+        content: 'Github Page',
+        url: 'https://strinova.fsltech.cn/',
+      },
+    ],
+    CN: [],
+  },
+  supportusdata: {
+    content: (
+      <>
+        <div>
+          <strong>STRINOVA MAP ASSISTANT</strong>is an open-source React
+          project.
+        </div>
+        <div>So you can use it freely under license GPL-3.0.</div>
+        <div>Some image source may need further permission.</div>
+        <div>Please ask the official.</div>
+        <br />
+        <div>
+          Even thougth, you can donate to the developers to make this project
+          better.
+        </div>
+        <div>
+          Whatever support you gave ,your would be listed on{' '}
+          <strong>STRINOVA MAP ASSISTANT</strong>'s namelist.
+        </div>
+        <div>
+          Contact <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a> if you
+          have any more requests.
+        </div>
+      </>
+    ),
+    global: 'International',
+    CN: 'CN',
+    list: 'Support List',
+  },
+  sidebar: {
+    attact: 'Attack',
+    defense: 'Defense',
+    mapsetting: 'Map Setting',
+    character: 'Character',
+    skill: 'Skills',
+    grenade: 'Grenades',
+    other: 'Others',
+    lineup: 'Grenade Lineups',
+    skilllineup: 'Skill Lineups',
+    mobaisuperjump: 'Baimo Super Jumps',
+    bugpoint: 'Bugs',
+    bugpointwarning: (
+      <div style={{ fontSize: '12px', textAlign: 'left' }}>
+        <div>Bugs listed here are for your information only!</div>
+        <div>
+          We are not responsible for any bans for abusing any of these bugs.
+        </div>
+      </div>
+    ),
+    learnmore: 'Learn More',
+    supportus: 'SUPPORT US',
+    supportusContent: <></>,
+  },
+  mapsetting: {
+    choosemap: 'Map',
+    maps: {
+      WindyTown: 'Windy Town',
+      SpaceLab: 'Space Lab',
+      Khesmet: 'Khesmet',
+      CauchyDistrict: 'Cauchy District',
+      EulerPort: 'Port Euler',
+      Area88: 'Area 88',
+      Base404: 'Base 404',
+      Ocarnus: 'Ocarnus',
+    },
+    TeamHighlight: 'Team Highlight',
+    TeamHighlightOptions: {
+      prepare: 'Show',
+      blank: 'Hide',
+    },
+    Landmarks: 'Landmarks',
+  },
+  lineupsetting: {
+    spotmark: 'Spot Mark',
+    spotmarks: {
+      disable: 'Disable',
+      available: 'Available Only',
+      all: 'All',
+    },
+  },
+  skilllineupsetting: {
+    spotmark: 'Spot Mark',
+    spotmarks: {
+      disable: 'Disable',
+      available: 'Available Only',
+      all: 'All',
+    },
+  },
+  mobaisuperjumpsetting: {
+    spotmark: 'Spot Mark',
+    spotmarks: {
+      disable: 'Disable',
+      available: 'Available Only',
+      all: 'All',
+    },
+  },
+  bugpointsetting: {
+    spotmark: 'Spot Mark',
+    spotmarks: {
+      disable: 'Disable',
+      available: 'Available Only',
+      all: 'All',
+    },
+  },
+  factions: {
+    PUS: 'PUS',
+    TheScissors: 'The Scissors',
+    Urbino: 'Urbino',
+  },
+  characters: {
+    PUS: {
+      Michele: 'Michele Li',
+      Nobunaga: 'Nobunaga',
+      Kokona: 'Kokona',
+      Yvette: 'Yvette',
+      Flavia: 'Flavia',
+      Yugiri: 'Yugiri',
+      Leona: 'Leona',
+    },
+    TheScissors: {
+      Ming: 'Ming',
+      Lawine: 'Lawine',
+      Meredith: 'Meredith',
+      Reiichi: 'Reiichi',
+      Kanami: 'Kanami',
+      Eika: 'Eika',
+      Fragrans: 'Fragrans',
+      Mara: 'Mara',
+    },
+    Urbino: {
+      Celestia: 'Celestia',
+      Audrey: 'Audrey',
+      Maddelena: 'Maddelena',
+      Fuchsia: 'Fuchsia',
+      BaiMo: 'Bai Mo',
+      Galatea: 'Galatea',
+    },
+  },
+  characterInfo: {
+    Michele: {
+      Name: 'Michele',
+      Type: 'Sentinel',
+      skillActiveName: `Meow Meow! Turret`,
+      skillActiveDescription: `Michele throws a small turret that attached to any surface (except player). The turret will automaticaly attack enemy (3 dmg/s) and slow them down.`,
+      skillPassiveName: `Cat Sense`,
+      skillPassiveDescription: `Enemy that damaged Michele will be highlighted for Michele and her teammates.`,
+      skillUltimateName: `Ultra! Meow Meow!`,
+      skillUltimateDescription: `Michele deploy a big Meow Meow Drone with powerful firepower. It will automaticaly attack enemy with bigger damage & range.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Nobunaga: {
+      Name: 'Nobunaga',
+      Type: 'Sentinel',
+      skillActiveName: `Observer`,
+      skillActiveDescription: `Nobunaga place a device on the ground which will gains Rate Of Fire, faster reload & restore Armor when he's within it range. Max 2 charges. If 2 Observer are placed within each other range, the buff effects are increased. It can be destroyed.`,
+      skillPassiveName: `Blinding Pulse`,
+      skillPassiveDescription: `When ADS, Nobunaga will build energy with his rifle. When fully charged, if enemy got hit by this charged shot, their crosshairs in ADS will be glitched out. Nobunaga's base Armor +10`,
+      skillUltimateName: `E.M.P`,
+      skillUltimateDescription: `Place a pulse device on the ground which emit large range pulse wave. Enemy within range will be highlighted & silenced continuously. It can be detroyed by any weapons.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Kokona: {
+      Name: 'Kokona',
+      Type: 'Support',
+      skillActiveName: `Healing Drone`,
+      skillActiveDescription: `Kokona sends a healing drone to heal and recover armor a selected ally or herself. Allies that stand near the drone will also healed.`,
+      skillPassiveName: `Emergency Rescue`,
+      skillPassiveDescription: `Kokona can summon a drone to auto-revive downed allies. Can revive multiple allies at the same time. Revived ally has 50 HP. Also Kokona restores 2 HP per second.`,
+      skillUltimateName: `Rebuild`,
+      skillUltimateDescription: `Kokona open up K.I.A terminal and choose an ally to resurrect using drones. The resurected ally will has full HP & Armor. It can be canceled either kill Kokona before she ults or destroy the drones when they resurrecting.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Yvette: {
+      Name: 'Yvette',
+      Type: 'Controller',
+      skillActiveName: `Fei`,
+      skillActiveDescription: `Yvette summon her teddy bear Fei to tranform into a real bear. Press the skill again to control Fei, Fei can dash forward to knock enemies up & leave an icy ground behind (2 charges). Which makes enemy slides & take more damage. Hold right mouse to recall Fei. Yvette is vulnerable while controlling Fei.`,
+      skillPassiveName: `Hidden Snow`,
+      skillPassiveDescription: `Yvette will go stealth after standing still for few secs. She can only be detected if going near her stealth range.`,
+      skillUltimateName: `Cold Breeze`,
+      skillUltimateDescription: `Yvette summon raging Fei that that slam the ground 3 times & create an icy ground which get bigger each slam. Enemy inside will slides, take more damage, slower Reload Speed, slower ADS Speed & slower Rate Of Fire.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Flavia: {
+      Name: 'Flavia',
+      Type: 'Duellist',
+      skillActiveName: `Illusory Phantom`,
+      skillActiveDescription: `Flavia summons the Phantom Butterfly to follows her for 5 seconds, during which time she loses 1HP from an attack, she becomes invincible for 2 seconds and spawns a Phantom Orb on the spot. The Phantom Orb will near-sight surrounding enemies and can be destroyed. Use the skill again to cancel invincible state instantly.`,
+      skillPassiveName: `Rebirth Circle`,
+      skillPassiveDescription: `Whenever Flavia takes 15 Damage, reduces Illusory Phantom's cooldown by 1 second. For every 160 damage taken, she gains 1 temporary Ultimate Point, which remains valid for the current round. Flavia's base armor +5'`,
+      skillUltimateName: `Dream Butterfly Transformation`,
+      skillUltimateDescription: `Flavia creates an illusionary field centered around herself. If she knocked out while in the field, Flavia'll transforms into a butterfly & revives herself after 3 seconds (repeat till ult ends). Enemies outside the field cannot see Flavia but they still can attack Flavia & will see Flavia if they attacked by her. If Flavia is killed by enemies outside the field, it will not trigger auto-revive & she'll die instantly.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Yugiri: {
+      Name: 'Yugiri',
+      Type: 'Controller',
+      skillActiveName: `Poison Mist`,
+      skillActiveDescription: `Throws a snail forward, creating a poisonous mist in a spherical area upon activation. The mist continuously lowers the maximum armour of enemies, which will then recover shortly after leaving the mist. Activating the snail will cost energy, and activating multiple snails will consume more energy then if one is activated. `,
+      skillPassiveName: `Toxic Fog Eruption`,
+      skillPassiveDescription: `After dealing a set amount of HP, she will cause an explosion within the enemy, affecting it with corrosion, temporarily corroding the nearby enemy’s shield. `,
+      skillUltimateName: `Poison Erosion`,
+      skillUltimateDescription: `Summons a large wave of mist that slowly advances forwards, reducing the max shields of any enemy struck and also applying the Corrosion effect. `,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Leona: {
+      Name: 'Leona',
+      Type: 'Sentinel',
+      skillActiveName: `KINETIC BARRIER`,
+      skillActiveDescription: `Leona generates square blocks with two-angle options on designated surfaces. Generating blocks consumes skill points and energy. Up to 16 blocks can exist at once.`,
+      skillPassiveName: `WORK-LIFE BALANCE`,
+      skillPassiveDescription: `While stringified, Leona continuously regenerates energy. When energy is above 50%, her movement speed increases; if below 50%, her armor gradually recovers.`,
+      skillUltimateName: `FORTRESS OF PURITY`,
+      skillUltimateDescription: `Leona fills her energy bar, making existing and newly generated blocks permanently transparent during the skill duration. Transparent blocks no longer block paths or ally bullets.`,
+      subName: `防弹护窗`,
+      subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
+    },
+    Ming: {
+      Name: 'Ming',
+      Type: 'Duellist',
+      skillActiveName: `Plasma Ball`,
+      skillActiveDescription: `Fires a ball of electricity that will automatically detonate when it reaches the maximum distance or hits an enemy superstring. It can also be manually detonated by pressing the skill key again. The ball of electricity will destroy the armor of all enemy units (including summons) within the range and slow them down. Ming will increase his movement speed when entering the electric field.`,
+      skillPassiveName: `Armor Absorbing`,
+      skillPassiveDescription: `When Ming uses firearms and active skills to damage the enemy's armor or shield, his armor will be restored based on the amount of damage. During the duration of the ultimate, the passive will restore temporary armor and increase the amount restored.`,
+      skillUltimateName: `Plasma Armor`,
+      skillUltimateDescription: `Ming gains temporary armor and applies a stackable slow to his shots. When Ming uses a gun or active skill to damage an enemy's armor, the skill's duration is extended and temporary armor is restored.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Lawine: {
+      Name: 'Lawine',
+      Type: 'Initiator',
+      skillActiveName: `Pulse Knife`,
+      skillActiveDescription: `Throws the Pulse Knife to create a large magnetic field, slowly highlight enemies within range to Lawine and her teammates. The pulse knife will disappear immediately after a failed scan. The pulse knife can scan up to 3 times and can be destroyed by any weapons & nades.`,
+      skillPassiveName: `Exposure Trace`,
+      skillPassiveDescription: `Enemy hit by Lawine's Primary Weapon will be highlighted. Only Lawine can see.`,
+      skillUltimateName: `Escape The Shadow`,
+      skillUltimateDescription: `Lawine creates a rectangular magnetic field in front. When entering the magnetic field, Lawine becomes invisible. Lawine cannot use any weapons while invisible.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Meredith: {
+      Name: 'Meredith',
+      Type: 'Controller',
+      skillActiveName: `Sand Heatwave`,
+      skillActiveDescription: `Meredith fires an energy orb which will creates a sand field when hit enemy or obstacles. All enemy inside will be slowed, reduces reload speed and their HP will reduces overtime.`,
+      skillPassiveName: `Time Warp`,
+      skillPassiveDescription: `Reduce Meredith's falling speed when aiming, using skills and nades.`,
+      skillUltimateName: `Quicksand Burial`,
+      skillUltimateDescription: `Meredith throws a pyramid artifact and create a massive sandstorm. All enemy inside will be near-sighted, HP reduced overtime, slowed down while being pulled to the center. Allies also got near-sighted.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Reiichi: {
+      Name: 'Reiichi',
+      Type: 'Controller',
+      skillActiveName: `Dawn Curtain`,
+      skillActiveDescription: `Reiichi uses his umbrella to create a curtain of Paper energy light that can be released vertically or horizontally, which obscures the field of view.`,
+      skillPassiveName: `Dawn Insight`,
+      skillPassiveDescription: `When in ADS, Reiichi will build up energy with his sniper. When fully charged, it will scan a small are in front of him & hightlight all enemy for himself & teammates.`,
+      skillUltimateName: `Sacred Screen of Refuge`,
+      skillUltimateDescription: `Immediately refresh Dawn Curtain, and enchance Dawn Curtain which now can block bullets from enemy. The blocking effect also applies to pre-use Dawn Curtain.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Kanami: {
+      Name: 'Kanami',
+      Type: 'Initiator',
+      skillActiveName: `Symphony`,
+      skillActiveDescription: `Kanami infuses her sniper with her melody, then shoot to any surface which will resonate and hightlight all enemy in it radius for Kanami & teammates.`,
+      skillPassiveName: `Sonic Boom`,
+      skillPassiveDescription: `When a bullet hit a target it will highlight enemy and ultilities through wall briefly.`,
+      skillUltimateName: `Showtime`,
+      skillUltimateDescription: `Kanami summon a hologram of herself, the music start playing which glitch out enemy scope in ADS while slowing & pulling them to the center.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Eika: {
+      Name: 'Eika',
+      Type: 'Duellist',
+      skillActiveName: `Hellfire Cage`,
+      skillActiveDescription: `Creates a fire cage in front of Aika that burns enemies who pass through its boundaries, and the cage disippates prematurely if there are no more enemies inside. When Aika enters the cage, her shotgun will deals additional burn damage against enemies within the cage. Casting the skill with 100 heat, the flame will turn to blue & enemy takes more damage.`,
+      skillPassiveName: `Reserve Flare`,
+      skillPassiveDescription: `When Aika deals damage to enemies, She gathers a small amount of heat for her heat gauge, up to a max of 100. At max heat, Aika deals bonus damage against paper-mode enemies and empowers her abilities.`,
+      skillUltimateName: `Firestorm`,
+      skillUltimateDescription: `Throws out up to 3 fireball that can explode into a tornado, lifting (like wind bomb effect) and pulling in enemies, dealing continuous fire damage to them. Casting the skill with 100 heat, increases the tornado's size, damage, as well as highlighting (Not through wall) any enemies caught within.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Fragrans: {
+      Name: 'Fragrans',
+      Type: 'Support',
+      skillActiveName: `Vibrant And Fragrant`,
+      skillActiveDescription: `Fragrans can release two limited quantities of perfumes. After being released, it will create a fragrance area centered on itself, and the area will increase the fire rate or movement speed of the ally, and the fragrance effect will gradually decrease over time, and eventually disappear.`,
+      skillPassiveName: `Revive The Aroma`,
+      skillPassiveDescription: `Fragrans emits a faint scent of recovery, and nearby teammates and herself slowly regenerate health.`,
+      skillUltimateName: `Intense Fragrance`,
+      skillUltimateDescription: `Fragrans will create an area of intense fragrance centered on herself, and allies in the area will gain a high rate of fire, increased movement speed, and health regeneration, the effect will not be decayed, and Fragrans will not be able to use weapons during the release, but will receive a significant damage reduction.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Mara: {
+      Name: 'Mara',
+      Type: 'Duellist',
+      skillActiveName: `Phantom Grip`,
+      skillActiveDescription: `Mara casts a phantom hand that targets the nearest standing enemy, pulling a Soul Orb from their body and slowing them down. Only Mara can attack the Soul Orb with her weapon. Damaging the Soul Orb partially inflicts armor-ignoring HP damage on the enemy. The Soul Orb shrinks when the enemy sidesteps or glides.`,
+      skillPassiveName: `Soul Reaver`,
+      skillPassiveDescription: `Mara recovers a portion of HP and deals extra armor-ignoring DMG when using her weapon on non-full-HP enemies. This recovery effect also applies to the Soul Orb DMG from her Active Skill.`,
+      skillUltimateName: `Grim Reaper`,
+      skillUltimateDescription: `Mara marks the nearest enemy, applying silence and making them visible only to her. If Mara participates in a knockdown or kill of this target, the mark transfers to the nearest standing enemy within range and resets its duration. The effect lasts until Mara dies or time runs out.`,
+      subName: `-`,
+      subDescription: `-`,
+    },
+    Celestia: {
+      Name: 'Celestia',
+      Type: 'Support',
+      skillActiveName: `Guardian Of The Star`,
+      skillActiveDescription: `Celestia targets an allied character with a guardian star, replenishing temporary armor. The star then returns to her, granting her the half of the original effect.`,
+      skillPassiveName: `Cosmos`,
+      skillPassiveDescription: `When allies is near Huxing, both allies & herself will regain Armor overtime (+2/s). `,
+      skillUltimateName: `Stargate`,
+      skillUltimateDescription: `Huxing open the Stargate and choose an ally across the map, immediately gains her & the chosen ally a huge Extra Armor, then she'll start build up enegry. When fully charged, Huxing will teleports to the chosen ally. It can be canceled if Huxing takes certain amount of damage or uses the skill again. When canceled Huxing will teleport back to where she used the skill, the Extra Armor Buff will not lost.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Audrey: {
+      Name: 'Audrey',
+      Type: 'Sentinel',
+      skillActiveName: `Heavy Fire`,
+      skillActiveDescription: `Audrey enters stationary state & cannot move. Greatly increase Rate Of Fire & Max Shield Limit of her MG. Her MG is no longer need to reload but will overheat overtime. Audrey MG no longer has recoil.`,
+      skillPassiveName: `Royal Shield`,
+      skillPassiveDescription: `Audrey will gains 30 Extra Armor when ADS. This Extra Armor will be restored shortly after the shield is broken. Audrey's base armor +5`,
+      skillUltimateName: `Bombardment`,
+      skillUltimateDescription: `Audrey enters stationary state & summon her grenade launcher that shoot out 6 incendiary round. Each round will bounce off the wall and explodes when hit the ground, creating 3 small area of fire causing damage overtime.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Maddelena: {
+      Name: 'Maddelena',
+      Type: 'Controller',
+      skillActiveName: `Color Binding`,
+      skillActiveDescription: `Maddelena fires a puddle of paint, enemies that pass through this puddle will be slowed and cannot use Paper Mode.`,
+      skillPassiveName: `Color Footprint`,
+      skillPassiveDescription: `Enemy hit by Maddelena' Primary Weapon or her skills will be slowed and leave footprints behind.`,
+      skillUltimateName: `Color Bubble`,
+      skillUltimateDescription: `Maddelena fires a giant bubble which will becomes bigger overtime, enemies within the bubble won't be able to use Paper Mode and leave their footprints. When the bubble explodes, it will apply slow and vulnerability effect to enemies within the blast area.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Fuchsia: {
+      Name: 'Fuchsia',
+      Type: 'Duellist',
+      skillActiveName: `Predator's Sense`,
+      skillActiveDescription: `Fuchsia senses surrounding enemies which highlights full HP enemies briefly & continiously for injured enemies. Sensing enemy will also increase Fuchsia's movement speed for short time.`,
+      skillPassiveName: `Fight To Feed`,
+      skillPassiveDescription: `When Fuchsia get a kill or assist, dead enemy will drop an Energy Crystal. She can go near and absorb it which will quickly restores herself 50HP.`,
+      skillUltimateName: `Bloodbath`,
+      skillUltimateDescription: `Fuchsia gains massive Rate Of Fire, faster Reload Speed, ADS Speed & Movement Speed. Predator's Sense will be enchanced & hightlight all enemies in her view. Absorbing Energy Crystal will extend the duration.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    BaiMo: {
+      Name: 'BaiMo',
+      Type: 'Duellist',
+      skillActiveName: `Skydance`,
+      skillActiveDescription: `Baimo quickly dash forward & immediately reload 2 shell to his shotgun. Getting a kill will refresh the skill.`,
+      skillPassiveName: `Hip-Hop Boom Color`,
+      skillPassiveDescription: `When BaiMo deals atleast 50 Damage to enemy, they Paper Mode is disabled for few secs.`,
+      skillUltimateName: `Let's Rock!`,
+      skillUltimateDescription: `BaiMo place a respawn beacon at selected area and the music starts playing. When killed or press the skill again, Baimo will teleport back to the beacon fully restore his HP.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Galatea: {
+      Name: 'Galatea',
+      Type: 'Initiator',
+      skillActiveName: `Flying Cards Flash`,
+      skillActiveDescription: `Galatea releases a card that flies out in an arc, and when the card touches the ground or wall, a clone will be generated, and Galatea can teleport to the location of the clone by pressing the interaction button, and the clone can be destroyed. Each clone can detect visible enemies within a 10-meter radius and expose them to Galatea and all of her teammates, as well as enemies attacking the clone for a short period of time`,
+      skillPassiveName: `Fraudulent Shadow`,
+      skillPassiveDescription: `When Galatea detaches from a wall, it leaves a clone at the wall sticker, and each time she gets off the wall, it will respawn again, and when the clone is damaged, it will passively enter the cooldown.`,
+      skillUltimateName: `Shadow Card Trick`,
+      skillUltimateDescription: `Galatea throws a bunch of cards in front of her, each of which spawns a clone and teleports Galatea.`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+  },
+  characterTypes: {
+    Sentinel: 'Sentinel',
+    Support: 'Support',
+    Controller: 'Controller',
+    Duellist: 'Duellist',
+    Initiator: 'Initiator',
+  },
+  grenades: {
+    Flashbang: 'Flashbang',
+    FragGrenade: 'Frag Grenade',
+    HealingGrenade: 'Healing Grenade',
+    Interceptor: 'Interceptor',
+    SlowGrenade: 'Slow Grenade',
+    SmokeBomb: 'Smoke Bomb',
+    Alarm: 'Alarm',
+    WindstormGrenade: 'Windstorm Grenade',
+    SnowBall: 'Snow Ball',
+  },
+  others: {
+    Bomb: 'Bomb',
+    BombA: 'Bomb A',
+    BombB: 'Bomb B',
+    BombC: 'Bomb C',
+    Focus: 'Focus',
+    Warning: 'Warning',
+    Flag: 'Flag',
+    Danger: 'Danger',
+  },
+  markbox: {
+    mark: 'Mark',
+    straightline: 'Straight Line',
+    arrowline: 'Arrow Line',
+    color: 'Color',
+    undo: 'Undo',
+    clear: 'Clear',
+    clearwarning: {
+      title: 'Confirm to clear all marks?',
+      content: 'This action cannot be undone',
+      ok: 'Confirm',
+      cancel: 'Cancel',
+      success: 'Cleared all markings',
+      failure: 'Failed to clear markings',
+    },
+  },
+};

--- a/src/data/languages/ja_JP.tsx
+++ b/src/data/languages/ja_JP.tsx
@@ -1,504 +1,590 @@
-import { FaGithub } from "react-icons/fa";
-import { Languages } from "../../types/interface";
+import { FaGithub } from 'react-icons/fa';
+import { Languages } from '../../types/interface';
 
 export default {
-	language: Languages.ja_JP,
-	title: 'Strinova マップアシスタント',
-	announcement: "Announcement",
-	friendlink: "Friend Link",
-	sitelist: "Switch Server",
-	announcementdata: {
-		notshowntoday: "Not show today",
-		pin: {
-			title: "Update",
-			date: "2025.4.23",
-			summary: "New Map & New Agent added.",
-			data: {}
-		},
-		history: []
-	},
-	friendlinkdata: {
-		classify: {
-			official: "official",
-			wiki: "Wiki",
-			others: "Others"
-		},
-		official:
-			[{
-				name: "",
-				icon: <img style={{ height: "35px", filter: "brightness(1000%) drop-shadow(0 0 2px rgba(var(--semi-grey-7))" }} src='https://game.gtimg.cn/images/kq/m/web20230505/sec_ordlogo.png' />,
-				url: "https://klbq.qq.com/",
-			}, {
-				name: "",
-				icon: <img style={{ height: "22px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-9))" }} src='https://klbq-web-cms.strinova.com/prod/strinova_static/home_v12/img/icon/logo-white.png' />,
-				url: "https://www.strinova.com/",
-			}],
-		wiki:
-			[{
-				name: "",
-				icon: <img style={{ height: "32px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-9))" }} src='https://s2.loli.net/2024/10/01/NQTMvDZ5ah4omYR.png' />,
-				url: "https://wiki.biligame.com/klbq/",
-			}, {
-				name: "Strinovajp Wiki",
-				icon: <></>,
-				url: "https://www.strinovajp-wiki.jp/index.html",
-			}, {
-				name: "",
-				icon: <img style={{ height: "22px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))" }} src='https://s2.loli.net/2024/10/01/R4UxmBPGd2f8kQ7.webp' />,
-				url: "https://strinova.wiki.gg/wiki/Strinova_Wiki",
-			}, {
-				name: "Miraheze Meta",
-				icon: <></>,
-				url: "https://strinova.org/wiki/",
-			}, {
-				name: "日本語wiki",
-				icon: <img style={{ height: "28px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))", marginRight: "8px" }} src='https://w.atwiki.jp/common/_img/atwiki_logo_small.svg?t=741a51e81c8c8d5fe9627b874ecad193' />,
-				url: "https://w.atwiki.jp/calabiyau_jp/",
-			},],
-		others:
-			[{
-				name: "自建房助手",
-				icon: <img style={{ height: "35px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))", marginRight: "8px" }} src='https://s2.loli.net/2024/10/01/pmYnw16rL2PQWBy.png' />,
-				url: "https://klbq.fsltech.cn/",
-			}],
-		contact: {
-			content: <div style={{ width: "100%", textAlign: "center" }}>
-				添加友链请联系 <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
-			</div>
-		}
-	},
-	sitelistdata: {
-		content: <>
-			<div>为了提供更快的访问速度以及减轻服务器压力，</div>
-			<div>我们开设了不同节点</div>
-		</>,
-		Global: [
-			{
-				icon: <><FaGithub style={{ color: "rgba(var(--semi-grey-9), 1)", fontSize: "20px", marginRight: "10px" }} /></>,
-				content: "Github Page",
-				url: "https://strinova.fsltech.cn/"
-			}
-		],
-		CN: [],
-	},
-	supportusdata: {
-		content: <>
-			<div><strong>卡拉彼丘地图助手</strong>是一款开源应用，</div>
-			<div>因此你可以免费在 GPL-3.0 开源协议的范畴下使用本应用。</div>
-			<div>美术资料与部分UI版权归原作者与官方所有，</div>
-			<div>请咨询对应作者与官方授权！</div>
-			<br />
-			<div>但即便如此，你的赞助也可以给予开发者前进的动力，让这个项目变得更好。</div>
-			<div>无论你使用何种形式赞助，你都可以在<strong>卡拉彼丘地图助手</strong>的 GitHub 项目主页和网站展示您的信息（个人主页、公司主页、GitHub 资料页等）。</div>
-			<div>如需展示，请在留言中留下需要展示的内容或将内容连同赞助收据发送至 <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a></div>
-		</>,
-		global: "国际",
-		CN: "中国境内",
-		list: "赞助列表"
-	},
-	sidebar: {
-		attact: 'Attack',
-		defense: 'Defense',
-		mapsetting: 'マップの設定',
-		character: 'キャラクター（超弦体）',
-		skill: 'スキル',
-		grenade: '戦術アイテム',
-		other: 'Others',
-		lineup: '戦術アイテムのポイント',
-		skilllineup: 'スキルポイント',
-		mobaisuperjump: '白墨スーパージャンプ',
-		bugpoint: 'プログラムエラー',
-		bugpointwarning: (
-			<div style={{ fontSize: '12px', textAlign: 'left' }}>
-				<div>ここにリストされているエラーは参照用です！</div>
-				<div>私たちはこれらの脆弱性を悪用する禁止令には責任を負いません。</div>
-			</div>
-		),
-		learnmore: '詳細',
-		supportus: 'SUPPORT US',
-		supportusContent: <></>
-	},
-	mapsetting: {
-		choosemap: 'マップ',
-		maps: {
-			WindyTown: 'ウィンディタウン',
-			SpaceLab: 'スペース研究センター',
-			Khesmet: '科斯迷特',
-			CauchyDistrict: 'コーシー街区',
-			EulerPort: 'オイラー港',
-			Area88: '88街区',
-			Base404: '404基地',
-			Ocarnus: '奥卡努斯'
-		},
-		TeamHighlight: 'チームハイライト',
-		TeamHighlightOptions: {
-			prepare: '表示',
-			blank: '非表示'
-		},
-		Landmarks: 'ランドマーク'
-	},
-	lineupsetting: {
-		spotmark: 'スポットマーク',
-		spotmarks: {
-			disable: '無効',
-			available: '可能なものだけ',
-			all: '全て'
-		}
-	},
-	skilllineupsetting: {
-		spotmark: 'スポットマーク',
-		spotmarks: {
-			disable: '無効',
-			available: '可能なものだけ',
-			all: '全て'
-		}
-	},
-	mobaisuperjumpsetting: {
-		spotmark: 'スポットマーク',
-		spotmarks: {
-			disable: '無効',
-			available: '可能なものだけ',
-			all: '全て'
-		}
-	},
-	bugpointsetting: {
-		spotmark: 'スポットマーク',
-		spotmarks: {
-			disable: '無効',
-			available: '可能なものだけ',
-			all: '全て'
-		}
-	},
-	factions: {
-		PUS: 'PUS',
-		TheScissors: 'シザーズ',
-		Urbino: 'ウルビノ'
-	},
-	characters: {
-		PUS: {
-			Michele: 'ミシェル',
-			Nobunaga: '信長',
-			Kokona: '心夏',
-			Yvette: 'イヴェット',
-			Flavia: 'フラヴィア',
-			Yugiri: "Yugiri",
-			Leona: "Leona"
-		},
-		TheScissors: {
-			Ming: 'ミン',
-			Lawine: 'ラヴィーネ',
-			Meredith: 'メレディス',
-			Reiichi: '令一',
-			Kanami: '香奈美',
-			Eika: 'アイカ',
-			Fragrans: 'フラグランス',
-			Mara:'マーラー'
-		},
-		Urbino: {
-			Celestia: '星理恵',
-			Audrey: 'オードリー',
-			Maddelena: 'マダレーナ',
-			Fuchsia: 'フューシャ',
-			BaiMo: '白墨',
-			Galatea: 'ガラテア'
-		}
-	},
-	characterInfo: {
-		Michele: {
-			Name: "ミシェル",
-			Type: "センチネル",
-			skillActiveName: `ネコさん砲`,
-			skillActiveDescription: `ミシェルは建物に付着するネコ型タレットを設置する。タレットは一定範囲内の敵を自動で攻撃し、スロー効果を付与する。タレットはミシェルから一定距離離れると休止状態になる`,
-			skillPassiveName: `索敵ジャミング`,
-			skillPassiveDescription: `ミシェルが敵からダメージを受けると、その敵は可視化状態になる`,
-			skillUltimateName: `ネコ型ガンドローン`,
-			skillUltimateDescription: `ミシェルは強力な火力を持つガンドローンを配置する。ガンドローンは一定範囲内の敵を自動で攻撃する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Nobunaga: {
-			Name: "信長",
-			Type: "センチネル",
-			skillActiveName: `ウォッチング・アイ`,
-			skillActiveDescription: `信長は最大2つのウォッチングアイを配置できる。ウォッチング・アイが作動するドメイン内では、信長の発射速度、エルゴノミクス、アーマー回復が向上する。また、ウォッチング・アイのドメインが重なると、これらの増益効果が強化される`,
-			skillPassiveName: `ブラインドパルス`,
-			skillPassiveDescription: `信長はADSモードで弾をチャージできる。完全にチャージされた弾が敵に命中すると、敵の照準線が消える`,
-			skillUltimateName: `オーバーロード`,
-			skillUltimateDescription: `信長はパルス発生装置を設置する。この装置から発射されるパルスにスキャンされた敵は可視化され、沈黙状態になる。可視化された敵の姿はチーム全体に共有される`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Kokona: {
-			Name: "心夏",
-			Type: "サポート",
-			skillActiveName: `ヒーリングドローン`,
-			skillActiveDescription: `心夏は自分または味方をターゲットにしてヒーリングドローンを生成する。ドローンはターゲットのアーマーを回復し、首位の味方全員のHPを回復する`,
-			skillPassiveName: `救急処置`,
-			skillPassiveDescription: `戦闘を離脱すると自身のHPをゆっくり回復する。心夏が味方を救援する時に、ヒーリングドローンを放出してチームメイトを戦場に復帰させる`,
-			skillUltimateName: `リモデリング`,
-			skillUltimateDescription: `心夏は死亡した味方を一人選び、自分の近くで復活させる`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Yvette: {
-			Name: "イヴェット",
-			Type: "コントローラー",
-			skillActiveName: `ガオガオ、フェイ出撃`,
-			skillActiveDescription: `イヴェットはクマ「フェイ」を召喚する。アクティブスキルを再発動するとフェイの視点に切り替え、フェイを操作する。フェイの操作中に攻撃キーを押すと、フェイは前方に向かって突進し、障害物にぶつかると停止する。そして、停止した位置に氷雪地帯を生成する。敵が氷雪地帯にいるとスリップ効果と弱体化（被ダメージ増加）が付与される`,
-			skillPassiveName: `コソコソゆきがくれ`,
-			skillPassiveDescription: `イヴェットは静止した状態で一定時間が経過するとカモフラージュ状態に入り、遠方の敵には見えなくなり、敵が近づくと徐々に姿が現れる`,
-			skillUltimateName: `ブルブルぶりざーど`,
-			skillUltimateDescription: `イヴェットは巨大なシロクマを召喚し、3回連続で極寒フィールドを展開する。フィールド内の敵はスリップ状態と弱体化状態になり、発射速度とエルゴノミクスが低下する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Flavia: {
-			Name: "フラヴィア",
-			Type: "デュエリスト",
-			skillActiveName: `幻惑の蝶`,
-			skillActiveDescription: `フラヴィアが幻惑蝶を召喚する。幻惑蝶が存在する間、フラヴィアがダメージを受けると、一時的に無敵状態となり、ファントムオーブを生成する。オーブは敵の視界を遮断し、一定のダメージを受けると破壊される`,
-			skillPassiveName: `生々流転`,
-			skillPassiveDescription: `フラヴィアはダメージを受けるたびにアクティブスキルのクールダウンが短縮される。大きなダメージを受けると、一時的なアルティメットポイントを獲得する。スキルで獲得したポイントはそのラウンド内のみ有効`,
-			skillUltimateName: `胡蝶の夢`,
-			skillUltimateDescription: `フラヴィアは自身を中心にフィールドを生成する。フィールド内の敵に倒されると、フラヴィアは蝶に変身し、短時間後に戦闘を続ける。フィールド外の敵にはこの効果は適用されない。フィールド外の敵はフラヴィアからの攻撃を受けると、フラヴィアを可視化できる`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Yugiri: {
-			Name: "ユウギリ",
-			Type: "コントローラー",
-			skillActiveName: `ドクギリマイマイ`,
-			skillActiveDescription: `カタツムリ型の装置を設置する。インタラクションキーで起動すると、敵のアーマーを一時的に減少させる球状の有毒な霧を生成する`,
-			skillPassiveName: `トキシックミスト`,
-			skillPassiveDescription: `メインウェポンを使用して敵のHPに一定量のダメージを与えたとき、敵の体内の腐食性毒素が爆発し、周囲の敵のアーマーを一時的に低下させる`,
-			skillUltimateName: `ポイズンフォグ`,
-			skillUltimateDescription: `広範囲の毒霧を召喚してゆっくりと前進し、範囲内の敵キャラクターのアーマー上限を減少させる、腐食性の毒素を注入する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Leona: {
-			Name: "蕾欧娜",
-			Type: "守护",
-			skillActiveName: `弦能掩墙`,
-			skillActiveDescription: `蕾欧娜可以在指定平地或斜坡生成两种角度的正方形建筑块。方块生成会消耗技能点数及弦能条。方块最多同时存在16个。`,
-			skillPassiveName: `劳逸结合`,
-			skillPassiveDescription: `蕾欧娜在弦化状态会持续恢复弦能，当弦能高于50%时，提高自身移动速度；低于50%时，逐渐恢复自身护甲。`,
-			skillUltimateName: `纯净坚城`,
-			skillUltimateDescription: `蕾欧娜充满弦能条，场上已存在方块和技能持续期间生成的方块永久变透明，透明方块将不再阻挡通路与友方子弹。`,
-			subName: `防弹护窗`,
-			subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
-		},
-		Ming: {
-			Name: "明",
-			Type: "デュエリスト",
-			skillActiveName: `プラズマフィールド`,
-			skillActiveDescription: `明が球電を発射し、最大距離に達するか、敵に接触または再発動すると爆発する。爆発は範囲内のすべての敵ユニット(召喚物を含む)のアーマーを破壊し、スロー効果を付与するプラズマフィールドを形成する。明がフィールド内に入ると移動速度が増加する`,
-			skillPassiveName: `エナジードレイン`,
-			skillPassiveDescription: `明は、武器やアクティブスキルで敵のアーマーやシールドにダメージを与えると、そのダメージに基づいて自身のアーマーを回復できる。アルティメットの持続時間中、パッシブで一時的なアーマーが回復し、回復量が増加する`,
-			skillUltimateName: `プラズマアーマー`,
-			skillUltimateDescription: `明は一時的なアーマーを獲得し、バレットが敵にヒットするとスロー効果を付与する。この効果は最大4層まで重ねられる。敵のアーマーにダメージを与えると、アルティメットの持続時間が延長され、アーマーも回復する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Lawine: {
-			Name: "ラヴィーネ",
-			Type: "イニシエーター",
-			skillActiveName: `影狩り`,
-			skillActiveDescription: `ラヴィーネはパルスナイフを投げ、パルス磁場を生成する。磁場内の敵はチームに可視化される。パルスナイフは敵を検出しない場合、または3回スキャン後に消失する`,
-			skillPassiveName: `影映し`,
-			skillPassiveDescription: `メイン武器で敵にダメージを与えると、敵が一時的にラヴィーネに可視化される`,
-			skillUltimateName: `影の帳`,
-			skillUltimateDescription: `ラヴィーネは前方に長方形の地場を生成する。磁場に入るとラヴィーネはステルス状態になり、攻撃とスキル発動が禁止される`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Meredith: {
-			Name: "メレディス",
-			Type: "コントローラー",
-			skillActiveName: `風塵`,
-			skillActiveDescription: `メレディスは弦力オーブを投げ、着地地点で風塵を引き起こす。風塵はフィールド内の敵の移動速度とエルゴノミクスを一時的に低下し、HPを継続的に減少する`,
-			skillPassiveName: `マミータイム`,
-			skillPassiveDescription: `メレディスが滞空中に武器、スキル、または戦術アイテムを使用し、敵を照準すると、落下速度が減少する`,
-			skillUltimateName: `ドゥアトへの砂葬`,
-			skillUltimateDescription: `メレディスはピラミッドを投げだし、巨大な砂嵐フィールドを生成する。砂嵐は敵の視界を遮り、HPを継続的に減少する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Reiichi: {
-			Name: "令一",
-			Type: "コントローラー",
-			skillActiveName: `オプティカルベール`,
-			skillActiveDescription: `令一が自分の傘を用いて、縦または横に展開可能な光の幕を作り出し、視界を遮る`,
-			skillPassiveName: `夜明けのインサイト`,
-			skillPassiveDescription: `ADSモード中、令一は周期的に前方の敵と召喚物をスキャンする。検出された敵の姿が一時的に令一に可視化される`,
-			skillUltimateName: `聖光のバリア`,
-			skillUltimateDescription: `令一のアクティブスキルは即座にリセットされ、光の幕がバリアにアップグレードされる。敵の弾丸はバリアに遮断される`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Kanami: {
-			Name: "香奈美",
-			Type: "イニシエーター",
-			skillActiveName: `エコーチャンバー`,
-			skillActiveDescription: `香奈美の次のショットはソナーディスクを発射し、着地地点の前方180°の範囲をスキャンして遮蔽物のない敵を検知する。検知された敵はチーム全体に可視化される`,
-			skillPassiveName: `サウンドポップ`,
-			skillPassiveDescription: `メイン武器の弾丸が着地するとソナーゾーンを生成する。ソナーゾーン内の敵は香奈美に短時間表示される`,
-			skillUltimateName: `ショータイム`,
-			skillUltimateDescription: `香奈美はホログラムライブを展開し、周囲の敵を引き寄せる。香奈美の歌に魅了された敵は減速し、照準もジャミングされる同時に、スタンされ、発射速度が低下する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Eika: {
-			Name: "アイカ",
-			Type: "デュエリスト",
-			skillActiveName: `イグニッションファイア`,
-			skillActiveDescription: `目の前に炎の檻を生成して、檻の壁を通過する敵に炎ダメージを与える。アイカが檻の中にいるとき、メイン武器が檻の中の敵へ追加の炎ダメージを与える。100ヒート：壁のダメージが増加する`,
-			skillPassiveName: `イグナイト`,
-			skillPassiveDescription: `銃撃が敵にあたると、最大100ヒートを獲得する。ヒートが最大のとき、弦化している敵に追加ダメージを与える。また、最大ヒート時に全てのヒートを消費して次のスキルを強化する`,
-			skillUltimateName: `プロミネンス`,
-			skillUltimateDescription: `最大3つの火炎嵐を放つ。嵐は敵を強制的に吹き飛ばして炎ダメージを与える。100ヒート：範囲が拡大、ダメージが増加して、敵が強調表示される`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Fragrans: {
-			Name: "フラグランス",
-			Type: "サポート",
-			skillActiveName: `活力のトワレ`,
-			skillActiveDescription: `フラグランスは回数制限のある2種類の香水を放つことができる。発動後、フラグランスを中心に香水のエリアが生成され、エリア内の味方の射撃速度、または移動速度が上昇する。このバフ効果は時間とともに徐々に減少していき、効果時間が切れると消滅する`,
-			skillPassiveName: `癒しのアロマ`,
-			skillPassiveDescription: `フラグランスは周囲の味方と自身のヘルスを徐々に回復する`,
-			skillUltimateName: `激情のパルファム`,
-			skillUltimateDescription: `フラグランスが自身を中心とした強力な香水エリアを生成し、エリア内の味方の射撃速度、移動速度を大幅に上昇させ、ヘルスを回復させる。効果時間中、フラグランスは弦化および武器の使用ができなくなる代わりに大幅なダメージ軽減効果を獲得する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Mara: {
-			Name: "Mara",
-			Type: "Duellist",
-			skillActiveName: `-`,
-			skillActiveDescription: `-`,
-			skillPassiveName: `-`,
-			skillPassiveDescription: `-`,
-			skillUltimateName: `-`,
-			skillUltimateDescription: `-`,
-			subName: `-`,
-			subDescription: `-`,
-		},
-		Celestia: {
-			Name: "星理恵",
-			Type: "サポート",
-			skillActiveName: `ステラアーク`,
-			skillActiveDescription: `星理恵がアクティブスキルを発動すると、ステラが自動的に周囲の味方1人を追跡し、その味方に一時的なアーマーを付与する。その後、ステラは星理恵に戻り、同じ効果を付与する`,
-			skillPassiveName: `ステラリング`,
-			skillPassiveDescription: `星理恵は周囲の味方と自身のアーマーを徐々に回復する`,
-			skillUltimateName: `ステラゲート`,
-			skillUltimateDescription: `アルティメット発動後、味方の距離マーカーが表示される。星理恵は味方を一人選び、自身とその味方のアーマーを増加し、相手の位置にテレポートする。ゲージが消える前に、アルティメットキーを押すと、テレポートはキャンセルされる。(アーマーの増加は維持される)`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Audrey: {
-			Name: "オードリー",
-			Type: "センチネル",
-			skillActiveName: `火力全開`,
-			skillActiveDescription: `オードリーがマシンガンを銃架に設置して展開モードに入ると、発射速度が大幅に上昇する。リコイルが消え、リロードも不要になる。連続射撃により、ゲージがMAXになるとオーバーヒート状態になり、一時的に射撃ができなくなる`,
-			skillPassiveName: `ロイヤルシールド`,
-			skillPassiveDescription: `オードリーがADSモードまたは展開モードに入ると、正面に防御シールドを生成する。展開モード中はシールドの最大値が増加する`,
-			skillUltimateName: `戦術爆撃`,
-			skillUltimateDescription: `オードリーは6発のグレネードを発射できるグレネードランチャーを設置する。グレネードが着地すると爆発し、破片が敵と自身にダメージを与える火炎地帯を生成する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Maddelena: {
-			Name: "マダレーナ",
-			Type: "コントローラー",
-			skillActiveName: `ペイントショット`,
-			skillActiveDescription: `マダレーナがペイントを射出し、着弾地点にペイントエリアを作り出す。エリア内では、敵が減速し、弦化が禁止され、足跡が可視化される`,
-			skillPassiveName: `ペイントトラック`,
-			skillPassiveDescription: `マダレーナのメイン武器で敵にダメージを与えると、敵にスロー状態になり、足跡が可視化される`,
-			skillUltimateName: `ペイントバブル`,
-			skillUltimateDescription: `マダレーナは巨大なバブルを発射する。バブル内の敵は弦化禁止状態になり、足跡が可視化される。バブルが破裂すると、爆発範囲内の敵にスロー効果と弱体化を追加で付与する`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Fuchsia: {
-			Name: "フューシャ",
-			Type: "デュエリスト",
-			skillActiveName: `ロレンチーニ`,
-			skillActiveDescription: `フューシャは並外れた近くで周囲の敵を探知し、自身にのみ一時的に可視化する。敵のHPが100以下になると、可視化が持続する。スキル範囲内に敵がいる場合、フューシャの移動速度が上昇する`,
-			skillPassiveName: `ホエールフォール`,
-			skillPassiveDescription: `フューシャがキルまたはアシストを取ると、倒された敵はその位置にエネルギー結晶をドロップする。フューシャが結晶に近づくと、自動的に吸収して自身のHPを回復する。ラウンド中に初めて結晶を獲得するとヒュｰシャのHPの最大値が増加する。この増加効果はラウンドが終了するまで継続する`,
-			skillUltimateName: `アドレナリン`,
-			skillUltimateDescription: `発射速度とエルゴノミクスが大幅に上昇する。アクティブスキルが発動すると、視界内の敵全体がハイライト表示される。エネルギー結晶を吸収すると、アルティメットの持続時間が延長される`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		BaiMo: {
-			Name: "ハクボク",
-			Type: "デュエリスト",
-			skillActiveName: `空で踊るぜ`,
-			skillActiveDescription: `弦化した白墨は前方に急速に突進し、メイン武器に弾薬を2発装填する。キルまたはアシストを取ると、クールダウンがリセットされる`,
-			skillPassiveName: `セイ・ホー！`,
-			skillPassiveDescription: `白墨のメイン武器からの単発射撃が敵に50以上のダメージを与えると、敵に弦化禁止状態を付与する`,
-			skillUltimateName: `リサイタルだ！`,
-			skillUltimateDescription: `ハクボクはビーコンを設置する。設置後、キーを再度押すと、ビーコンの位置にテレポートし、HPが完全に回復する。死亡またはダウンした場合も、ビーコンの位置でリスポーンできる`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		},
-		Galatea: {
-			Name: "ガラテア",
-			Type: "イニシエーター",
-			skillActiveName: `ピルエット`,
-			skillActiveDescription: `ガラテアがカードを放ち、壁や床に触れると破壊可能な分身を作り出す。ガラテアの分身は発生した瞬間に周囲の敵と召喚物を可視化状態にし、ガラテアと味方に共有する。また、分身を破壊した敵を一時的に可視化する。インタラクションボタンを押すと分身を破壊してテレポートする`,
-			skillPassiveName: `ミスディレクション`,
-			skillPassiveDescription: `ガラテアが壁張りつきを解除すると分身を残す。分身が破壊されるとクールダウンが発生する`,
-			skillUltimateName: `イリュージョン`,
-			skillUltimateDescription: `ガラテアがカードを3枚放ち、3体の分身を生成する。各分身にテレポートすることができる`,
-			subName: `subName`,
-			subDescription: `subDescription`,
-		}
-	},
-	characterTypes: {
-		Sentinel: 'センチネル',
-		Support: 'サポート',
-		Controller: 'コントローラー',
-		Duellist: 'デュエリスト',
-		Initiator: 'イニシエーター'
-	},
-	grenades: {
-		Flashbang: '閃光弹',
-		FragGrenade: 'フラググレネード',
-		HealingGrenade: '回復グレネード',
-		Interceptor: 'インターセプター',
-		SlowGrenade: '减速ボム',
-		SmokeBomb: '煙幕弾',
-		Alarm: '警報器',
-		WindstormGrenade: '風雷ボム',
-		SnowBall: '雪玉'
-	},
-	others: {
-		Bomb: 'Bomb',
-		BombA: 'Bomb A',
-		BombB: 'Bomb B',
-		BombC: 'Bomb C',
-		Focus: 'Focus',
-		Warning: 'Warning',
-		Flag: 'Flag',
-		Danger: 'Danger',
-	},
-	markbox: {
-		mark: 'マーク',
-		straightline: '直線',
-		arrowline: 'Arrow Line',
-		color: 'カラー',
-		undo: '戻す',
-		clear: '消去',
-		clearwarning: {
-			title: '全てのマークを消去しますか?',
-			content: 'この操作は元に戻せません',
-			ok: '確認',
-			cancel: 'キャンセル',
-			success: '全てのマークを消去しました',
-			failure: 'マークの削除に失敗しました'
-		}
-	}
-}
+  language: Languages.ja_JP,
+  title: 'Strinova マップアシスタント',
+  announcement: 'Announcement',
+  friendlink: 'Friend Link',
+  sitelist: 'Switch Server',
+  announcementdata: {
+    notshowntoday: 'Not show today',
+    pin: {
+      title: 'Update',
+      date: '2025.4.23',
+      summary: 'New Map & New Agent added.',
+      data: {},
+    },
+    history: [],
+  },
+  friendlinkdata: {
+    classify: {
+      official: 'official',
+      wiki: 'Wiki',
+      others: 'Others',
+    },
+    official: [
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '35px',
+              filter:
+                'brightness(1000%) drop-shadow(0 0 2px rgba(var(--semi-grey-7))',
+            }}
+            src='https://game.gtimg.cn/images/kq/m/web20230505/sec_ordlogo.png'
+          />
+        ),
+        url: 'https://klbq.qq.com/',
+      },
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '22px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-9))',
+            }}
+            src='https://klbq-web-cms.strinova.com/prod/strinova_static/home_v12/img/icon/logo-white.png'
+          />
+        ),
+        url: 'https://www.strinova.com/',
+      },
+    ],
+    wiki: [
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '32px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-9))',
+            }}
+            src='https://s2.loli.net/2024/10/01/NQTMvDZ5ah4omYR.png'
+          />
+        ),
+        url: 'https://wiki.biligame.com/klbq/',
+      },
+      {
+        name: 'Strinovajp Wiki',
+        icon: <></>,
+        url: 'https://www.strinovajp-wiki.jp/index.html',
+      },
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '22px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+            }}
+            src='https://s2.loli.net/2024/10/01/R4UxmBPGd2f8kQ7.webp'
+          />
+        ),
+        url: 'https://strinova.wiki.gg/wiki/Strinova_Wiki',
+      },
+      {
+        name: 'Miraheze Meta',
+        icon: <></>,
+        url: 'https://strinova.org/wiki/',
+      },
+      {
+        name: '日本語wiki',
+        icon: (
+          <img
+            style={{
+              height: '28px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+              marginRight: '8px',
+            }}
+            src='https://w.atwiki.jp/common/_img/atwiki_logo_small.svg?t=741a51e81c8c8d5fe9627b874ecad193'
+          />
+        ),
+        url: 'https://w.atwiki.jp/calabiyau_jp/',
+      },
+    ],
+    others: [
+      {
+        name: '自建房助手',
+        icon: (
+          <img
+            style={{
+              height: '35px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+              marginRight: '8px',
+            }}
+            src='https://s2.loli.net/2024/10/01/pmYnw16rL2PQWBy.png'
+          />
+        ),
+        url: 'https://klbq.fsltech.cn/',
+      },
+    ],
+    contact: {
+      content: (
+        <div style={{ width: '100%', textAlign: 'center' }}>
+          添加友链请联系 <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
+        </div>
+      ),
+    },
+  },
+  sitelistdata: {
+    content: (
+      <>
+        <div>为了提供更快的访问速度以及减轻服务器压力，</div>
+        <div>我们开设了不同节点</div>
+      </>
+    ),
+    Global: [
+      {
+        icon: (
+          <>
+            <FaGithub
+              style={{
+                color: 'rgba(var(--semi-grey-9), 1)',
+                fontSize: '20px',
+                marginRight: '10px',
+              }}
+            />
+          </>
+        ),
+        content: 'Github Page',
+        url: 'https://strinova.fsltech.cn/',
+      },
+    ],
+    CN: [],
+  },
+  supportusdata: {
+    content: (
+      <>
+        <div>
+          <strong>卡拉彼丘地图助手</strong>是一款开源应用，
+        </div>
+        <div>因此你可以免费在 GPL-3.0 开源协议的范畴下使用本应用。</div>
+        <div>美术资料与部分UI版权归原作者与官方所有，</div>
+        <div>请咨询对应作者与官方授权！</div>
+        <br />
+        <div>
+          但即便如此，你的赞助也可以给予开发者前进的动力，让这个项目变得更好。
+        </div>
+        <div>
+          无论你使用何种形式赞助，你都可以在<strong>卡拉彼丘地图助手</strong>的
+          GitHub 项目主页和网站展示您的信息（个人主页、公司主页、GitHub
+          资料页等）。
+        </div>
+        <div>
+          如需展示，请在留言中留下需要展示的内容或将内容连同赞助收据发送至{' '}
+          <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
+        </div>
+      </>
+    ),
+    global: '国际',
+    CN: '中国境内',
+    list: '赞助列表',
+  },
+  sidebar: {
+    attact: 'Attack',
+    defense: 'Defense',
+    mapsetting: 'マップの設定',
+    character: 'キャラクター（超弦体）',
+    skill: 'スキル',
+    grenade: '戦術アイテム',
+    other: 'Others',
+    lineup: '戦術アイテムのポイント',
+    skilllineup: 'スキルポイント',
+    mobaisuperjump: '白墨スーパージャンプ',
+    bugpoint: 'プログラムエラー',
+    bugpointwarning: (
+      <div style={{ fontSize: '12px', textAlign: 'left' }}>
+        <div>ここにリストされているエラーは参照用です！</div>
+        <div>私たちはこれらの脆弱性を悪用する禁止令には責任を負いません。</div>
+      </div>
+    ),
+    learnmore: '詳細',
+    supportus: 'SUPPORT US',
+    supportusContent: <></>,
+  },
+  mapsetting: {
+    choosemap: 'マップ',
+    maps: {
+      WindyTown: 'ウィンディタウン',
+      SpaceLab: 'スペース研究センター',
+      Khesmet: '科斯迷特',
+      CauchyDistrict: 'コーシー街区',
+      EulerPort: 'オイラー港',
+      Area88: '88街区',
+      Base404: '404基地',
+      Ocarnus: '奥卡努斯',
+    },
+    TeamHighlight: 'チームハイライト',
+    TeamHighlightOptions: {
+      prepare: '表示',
+      blank: '非表示',
+    },
+    Landmarks: 'ランドマーク',
+  },
+  lineupsetting: {
+    spotmark: 'スポットマーク',
+    spotmarks: {
+      disable: '無効',
+      available: '可能なものだけ',
+      all: '全て',
+    },
+  },
+  skilllineupsetting: {
+    spotmark: 'スポットマーク',
+    spotmarks: {
+      disable: '無効',
+      available: '可能なものだけ',
+      all: '全て',
+    },
+  },
+  mobaisuperjumpsetting: {
+    spotmark: 'スポットマーク',
+    spotmarks: {
+      disable: '無効',
+      available: '可能なものだけ',
+      all: '全て',
+    },
+  },
+  bugpointsetting: {
+    spotmark: 'スポットマーク',
+    spotmarks: {
+      disable: '無効',
+      available: '可能なものだけ',
+      all: '全て',
+    },
+  },
+  factions: {
+    PUS: 'PUS',
+    TheScissors: 'シザーズ',
+    Urbino: 'ウルビノ',
+  },
+  characters: {
+    PUS: {
+      Michele: 'ミシェル',
+      Nobunaga: '信長',
+      Kokona: '心夏',
+      Yvette: 'イヴェット',
+      Flavia: 'フラヴィア',
+      Yugiri: 'Yugiri',
+      Leona: 'Leona',
+    },
+    TheScissors: {
+      Ming: 'ミン',
+      Lawine: 'ラヴィーネ',
+      Meredith: 'メレディス',
+      Reiichi: '令一',
+      Kanami: '香奈美',
+      Eika: 'アイカ',
+      Fragrans: 'フラグランス',
+      Mara: 'マーラー',
+    },
+    Urbino: {
+      Celestia: '星理恵',
+      Audrey: 'オードリー',
+      Maddelena: 'マダレーナ',
+      Fuchsia: 'フューシャ',
+      BaiMo: '白墨',
+      Galatea: 'ガラテア',
+    },
+  },
+  characterInfo: {
+    Michele: {
+      Name: 'ミシェル',
+      Type: 'センチネル',
+      skillActiveName: `ネコさん砲`,
+      skillActiveDescription: `ミシェルは建物に付着するネコ型タレットを設置する。タレットは一定範囲内の敵を自動で攻撃し、スロー効果を付与する。タレットはミシェルから一定距離離れると休止状態になる`,
+      skillPassiveName: `索敵ジャミング`,
+      skillPassiveDescription: `ミシェルが敵からダメージを受けると、その敵は可視化状態になる`,
+      skillUltimateName: `ネコ型ガンドローン`,
+      skillUltimateDescription: `ミシェルは強力な火力を持つガンドローンを配置する。ガンドローンは一定範囲内の敵を自動で攻撃する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Nobunaga: {
+      Name: '信長',
+      Type: 'センチネル',
+      skillActiveName: `ウォッチング・アイ`,
+      skillActiveDescription: `信長は最大2つのウォッチングアイを配置できる。ウォッチング・アイが作動するドメイン内では、信長の発射速度、エルゴノミクス、アーマー回復が向上する。また、ウォッチング・アイのドメインが重なると、これらの増益効果が強化される`,
+      skillPassiveName: `ブラインドパルス`,
+      skillPassiveDescription: `信長はADSモードで弾をチャージできる。完全にチャージされた弾が敵に命中すると、敵の照準線が消える`,
+      skillUltimateName: `オーバーロード`,
+      skillUltimateDescription: `信長はパルス発生装置を設置する。この装置から発射されるパルスにスキャンされた敵は可視化され、沈黙状態になる。可視化された敵の姿はチーム全体に共有される`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Kokona: {
+      Name: '心夏',
+      Type: 'サポート',
+      skillActiveName: `ヒーリングドローン`,
+      skillActiveDescription: `心夏は自分または味方をターゲットにしてヒーリングドローンを生成する。ドローンはターゲットのアーマーを回復し、首位の味方全員のHPを回復する`,
+      skillPassiveName: `救急処置`,
+      skillPassiveDescription: `戦闘を離脱すると自身のHPをゆっくり回復する。心夏が味方を救援する時に、ヒーリングドローンを放出してチームメイトを戦場に復帰させる`,
+      skillUltimateName: `リモデリング`,
+      skillUltimateDescription: `心夏は死亡した味方を一人選び、自分の近くで復活させる`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Yvette: {
+      Name: 'イヴェット',
+      Type: 'コントローラー',
+      skillActiveName: `ガオガオ、フェイ出撃`,
+      skillActiveDescription: `イヴェットはクマ「フェイ」を召喚する。アクティブスキルを再発動するとフェイの視点に切り替え、フェイを操作する。フェイの操作中に攻撃キーを押すと、フェイは前方に向かって突進し、障害物にぶつかると停止する。そして、停止した位置に氷雪地帯を生成する。敵が氷雪地帯にいるとスリップ効果と弱体化（被ダメージ増加）が付与される`,
+      skillPassiveName: `コソコソゆきがくれ`,
+      skillPassiveDescription: `イヴェットは静止した状態で一定時間が経過するとカモフラージュ状態に入り、遠方の敵には見えなくなり、敵が近づくと徐々に姿が現れる`,
+      skillUltimateName: `ブルブルぶりざーど`,
+      skillUltimateDescription: `イヴェットは巨大なシロクマを召喚し、3回連続で極寒フィールドを展開する。フィールド内の敵はスリップ状態と弱体化状態になり、発射速度とエルゴノミクスが低下する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Flavia: {
+      Name: 'フラヴィア',
+      Type: 'デュエリスト',
+      skillActiveName: `幻惑の蝶`,
+      skillActiveDescription: `フラヴィアが幻惑蝶を召喚する。幻惑蝶が存在する間、フラヴィアがダメージを受けると、一時的に無敵状態となり、ファントムオーブを生成する。オーブは敵の視界を遮断し、一定のダメージを受けると破壊される`,
+      skillPassiveName: `生々流転`,
+      skillPassiveDescription: `フラヴィアはダメージを受けるたびにアクティブスキルのクールダウンが短縮される。大きなダメージを受けると、一時的なアルティメットポイントを獲得する。スキルで獲得したポイントはそのラウンド内のみ有効`,
+      skillUltimateName: `胡蝶の夢`,
+      skillUltimateDescription: `フラヴィアは自身を中心にフィールドを生成する。フィールド内の敵に倒されると、フラヴィアは蝶に変身し、短時間後に戦闘を続ける。フィールド外の敵にはこの効果は適用されない。フィールド外の敵はフラヴィアからの攻撃を受けると、フラヴィアを可視化できる`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Yugiri: {
+      Name: 'ユウギリ',
+      Type: 'コントローラー',
+      skillActiveName: `ドクギリマイマイ`,
+      skillActiveDescription: `カタツムリ型の装置を設置する。インタラクションキーで起動すると、敵のアーマーを一時的に減少させる球状の有毒な霧を生成する`,
+      skillPassiveName: `トキシックミスト`,
+      skillPassiveDescription: `メインウェポンを使用して敵のHPに一定量のダメージを与えたとき、敵の体内の腐食性毒素が爆発し、周囲の敵のアーマーを一時的に低下させる`,
+      skillUltimateName: `ポイズンフォグ`,
+      skillUltimateDescription: `広範囲の毒霧を召喚してゆっくりと前進し、範囲内の敵キャラクターのアーマー上限を減少させる、腐食性の毒素を注入する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Leona: {
+      Name: '蕾欧娜',
+      Type: '守护',
+      skillActiveName: `弦能掩墙`,
+      skillActiveDescription: `蕾欧娜可以在指定平地或斜坡生成两种角度的正方形建筑块。方块生成会消耗技能点数及弦能条。方块最多同时存在16个。`,
+      skillPassiveName: `劳逸结合`,
+      skillPassiveDescription: `蕾欧娜在弦化状态会持续恢复弦能，当弦能高于50%时，提高自身移动速度；低于50%时，逐渐恢复自身护甲。`,
+      skillUltimateName: `纯净坚城`,
+      skillUltimateDescription: `蕾欧娜充满弦能条，场上已存在方块和技能持续期间生成的方块永久变透明，透明方块将不再阻挡通路与友方子弹。`,
+      subName: `防弹护窗`,
+      subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
+    },
+    Ming: {
+      Name: '明',
+      Type: 'デュエリスト',
+      skillActiveName: `プラズマフィールド`,
+      skillActiveDescription: `明が球電を発射し、最大距離に達するか、敵に接触または再発動すると爆発する。爆発は範囲内のすべての敵ユニット(召喚物を含む)のアーマーを破壊し、スロー効果を付与するプラズマフィールドを形成する。明がフィールド内に入ると移動速度が増加する`,
+      skillPassiveName: `エナジードレイン`,
+      skillPassiveDescription: `明は、武器やアクティブスキルで敵のアーマーやシールドにダメージを与えると、そのダメージに基づいて自身のアーマーを回復できる。アルティメットの持続時間中、パッシブで一時的なアーマーが回復し、回復量が増加する`,
+      skillUltimateName: `プラズマアーマー`,
+      skillUltimateDescription: `明は一時的なアーマーを獲得し、バレットが敵にヒットするとスロー効果を付与する。この効果は最大4層まで重ねられる。敵のアーマーにダメージを与えると、アルティメットの持続時間が延長され、アーマーも回復する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Lawine: {
+      Name: 'ラヴィーネ',
+      Type: 'イニシエーター',
+      skillActiveName: `影狩り`,
+      skillActiveDescription: `ラヴィーネはパルスナイフを投げ、パルス磁場を生成する。磁場内の敵はチームに可視化される。パルスナイフは敵を検出しない場合、または3回スキャン後に消失する`,
+      skillPassiveName: `影映し`,
+      skillPassiveDescription: `メイン武器で敵にダメージを与えると、敵が一時的にラヴィーネに可視化される`,
+      skillUltimateName: `影の帳`,
+      skillUltimateDescription: `ラヴィーネは前方に長方形の地場を生成する。磁場に入るとラヴィーネはステルス状態になり、攻撃とスキル発動が禁止される`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Meredith: {
+      Name: 'メレディス',
+      Type: 'コントローラー',
+      skillActiveName: `風塵`,
+      skillActiveDescription: `メレディスは弦力オーブを投げ、着地地点で風塵を引き起こす。風塵はフィールド内の敵の移動速度とエルゴノミクスを一時的に低下し、HPを継続的に減少する`,
+      skillPassiveName: `マミータイム`,
+      skillPassiveDescription: `メレディスが滞空中に武器、スキル、または戦術アイテムを使用し、敵を照準すると、落下速度が減少する`,
+      skillUltimateName: `ドゥアトへの砂葬`,
+      skillUltimateDescription: `メレディスはピラミッドを投げだし、巨大な砂嵐フィールドを生成する。砂嵐は敵の視界を遮り、HPを継続的に減少する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Reiichi: {
+      Name: '令一',
+      Type: 'コントローラー',
+      skillActiveName: `オプティカルベール`,
+      skillActiveDescription: `令一が自分の傘を用いて、縦または横に展開可能な光の幕を作り出し、視界を遮る`,
+      skillPassiveName: `夜明けのインサイト`,
+      skillPassiveDescription: `ADSモード中、令一は周期的に前方の敵と召喚物をスキャンする。検出された敵の姿が一時的に令一に可視化される`,
+      skillUltimateName: `聖光のバリア`,
+      skillUltimateDescription: `令一のアクティブスキルは即座にリセットされ、光の幕がバリアにアップグレードされる。敵の弾丸はバリアに遮断される`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Kanami: {
+      Name: '香奈美',
+      Type: 'イニシエーター',
+      skillActiveName: `エコーチャンバー`,
+      skillActiveDescription: `香奈美の次のショットはソナーディスクを発射し、着地地点の前方180°の範囲をスキャンして遮蔽物のない敵を検知する。検知された敵はチーム全体に可視化される`,
+      skillPassiveName: `サウンドポップ`,
+      skillPassiveDescription: `メイン武器の弾丸が着地するとソナーゾーンを生成する。ソナーゾーン内の敵は香奈美に短時間表示される`,
+      skillUltimateName: `ショータイム`,
+      skillUltimateDescription: `香奈美はホログラムライブを展開し、周囲の敵を引き寄せる。香奈美の歌に魅了された敵は減速し、照準もジャミングされる同時に、スタンされ、発射速度が低下する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Eika: {
+      Name: 'アイカ',
+      Type: 'デュエリスト',
+      skillActiveName: `イグニッションファイア`,
+      skillActiveDescription: `目の前に炎の檻を生成して、檻の壁を通過する敵に炎ダメージを与える。アイカが檻の中にいるとき、メイン武器が檻の中の敵へ追加の炎ダメージを与える。100ヒート：壁のダメージが増加する`,
+      skillPassiveName: `イグナイト`,
+      skillPassiveDescription: `銃撃が敵にあたると、最大100ヒートを獲得する。ヒートが最大のとき、弦化している敵に追加ダメージを与える。また、最大ヒート時に全てのヒートを消費して次のスキルを強化する`,
+      skillUltimateName: `プロミネンス`,
+      skillUltimateDescription: `最大3つの火炎嵐を放つ。嵐は敵を強制的に吹き飛ばして炎ダメージを与える。100ヒート：範囲が拡大、ダメージが増加して、敵が強調表示される`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Fragrans: {
+      Name: 'フラグランス',
+      Type: 'サポート',
+      skillActiveName: `活力のトワレ`,
+      skillActiveDescription: `フラグランスは回数制限のある2種類の香水を放つことができる。発動後、フラグランスを中心に香水のエリアが生成され、エリア内の味方の射撃速度、または移動速度が上昇する。このバフ効果は時間とともに徐々に減少していき、効果時間が切れると消滅する`,
+      skillPassiveName: `癒しのアロマ`,
+      skillPassiveDescription: `フラグランスは周囲の味方と自身のヘルスを徐々に回復する`,
+      skillUltimateName: `激情のパルファム`,
+      skillUltimateDescription: `フラグランスが自身を中心とした強力な香水エリアを生成し、エリア内の味方の射撃速度、移動速度を大幅に上昇させ、ヘルスを回復させる。効果時間中、フラグランスは弦化および武器の使用ができなくなる代わりに大幅なダメージ軽減効果を獲得する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Mara: {
+      Name: 'Mara',
+      Type: 'Duellist',
+      skillActiveName: `-`,
+      skillActiveDescription: `-`,
+      skillPassiveName: `-`,
+      skillPassiveDescription: `-`,
+      skillUltimateName: `-`,
+      skillUltimateDescription: `-`,
+      subName: `-`,
+      subDescription: `-`,
+    },
+    Celestia: {
+      Name: '星理恵',
+      Type: 'サポート',
+      skillActiveName: `ステラアーク`,
+      skillActiveDescription: `星理恵がアクティブスキルを発動すると、ステラが自動的に周囲の味方1人を追跡し、その味方に一時的なアーマーを付与する。その後、ステラは星理恵に戻り、同じ効果を付与する`,
+      skillPassiveName: `ステラリング`,
+      skillPassiveDescription: `星理恵は周囲の味方と自身のアーマーを徐々に回復する`,
+      skillUltimateName: `ステラゲート`,
+      skillUltimateDescription: `アルティメット発動後、味方の距離マーカーが表示される。星理恵は味方を一人選び、自身とその味方のアーマーを増加し、相手の位置にテレポートする。ゲージが消える前に、アルティメットキーを押すと、テレポートはキャンセルされる。(アーマーの増加は維持される)`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Audrey: {
+      Name: 'オードリー',
+      Type: 'センチネル',
+      skillActiveName: `火力全開`,
+      skillActiveDescription: `オードリーがマシンガンを銃架に設置して展開モードに入ると、発射速度が大幅に上昇する。リコイルが消え、リロードも不要になる。連続射撃により、ゲージがMAXになるとオーバーヒート状態になり、一時的に射撃ができなくなる`,
+      skillPassiveName: `ロイヤルシールド`,
+      skillPassiveDescription: `オードリーがADSモードまたは展開モードに入ると、正面に防御シールドを生成する。展開モード中はシールドの最大値が増加する`,
+      skillUltimateName: `戦術爆撃`,
+      skillUltimateDescription: `オードリーは6発のグレネードを発射できるグレネードランチャーを設置する。グレネードが着地すると爆発し、破片が敵と自身にダメージを与える火炎地帯を生成する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Maddelena: {
+      Name: 'マダレーナ',
+      Type: 'コントローラー',
+      skillActiveName: `ペイントショット`,
+      skillActiveDescription: `マダレーナがペイントを射出し、着弾地点にペイントエリアを作り出す。エリア内では、敵が減速し、弦化が禁止され、足跡が可視化される`,
+      skillPassiveName: `ペイントトラック`,
+      skillPassiveDescription: `マダレーナのメイン武器で敵にダメージを与えると、敵にスロー状態になり、足跡が可視化される`,
+      skillUltimateName: `ペイントバブル`,
+      skillUltimateDescription: `マダレーナは巨大なバブルを発射する。バブル内の敵は弦化禁止状態になり、足跡が可視化される。バブルが破裂すると、爆発範囲内の敵にスロー効果と弱体化を追加で付与する`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Fuchsia: {
+      Name: 'フューシャ',
+      Type: 'デュエリスト',
+      skillActiveName: `ロレンチーニ`,
+      skillActiveDescription: `フューシャは並外れた近くで周囲の敵を探知し、自身にのみ一時的に可視化する。敵のHPが100以下になると、可視化が持続する。スキル範囲内に敵がいる場合、フューシャの移動速度が上昇する`,
+      skillPassiveName: `ホエールフォール`,
+      skillPassiveDescription: `フューシャがキルまたはアシストを取ると、倒された敵はその位置にエネルギー結晶をドロップする。フューシャが結晶に近づくと、自動的に吸収して自身のHPを回復する。ラウンド中に初めて結晶を獲得するとヒュｰシャのHPの最大値が増加する。この増加効果はラウンドが終了するまで継続する`,
+      skillUltimateName: `アドレナリン`,
+      skillUltimateDescription: `発射速度とエルゴノミクスが大幅に上昇する。アクティブスキルが発動すると、視界内の敵全体がハイライト表示される。エネルギー結晶を吸収すると、アルティメットの持続時間が延長される`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    BaiMo: {
+      Name: 'ハクボク',
+      Type: 'デュエリスト',
+      skillActiveName: `空で踊るぜ`,
+      skillActiveDescription: `弦化した白墨は前方に急速に突進し、メイン武器に弾薬を2発装填する。キルまたはアシストを取ると、クールダウンがリセットされる`,
+      skillPassiveName: `セイ・ホー！`,
+      skillPassiveDescription: `白墨のメイン武器からの単発射撃が敵に50以上のダメージを与えると、敵に弦化禁止状態を付与する`,
+      skillUltimateName: `リサイタルだ！`,
+      skillUltimateDescription: `ハクボクはビーコンを設置する。設置後、キーを再度押すと、ビーコンの位置にテレポートし、HPが完全に回復する。死亡またはダウンした場合も、ビーコンの位置でリスポーンできる`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+    Galatea: {
+      Name: 'ガラテア',
+      Type: 'イニシエーター',
+      skillActiveName: `ピルエット`,
+      skillActiveDescription: `ガラテアがカードを放ち、壁や床に触れると破壊可能な分身を作り出す。ガラテアの分身は発生した瞬間に周囲の敵と召喚物を可視化状態にし、ガラテアと味方に共有する。また、分身を破壊した敵を一時的に可視化する。インタラクションボタンを押すと分身を破壊してテレポートする`,
+      skillPassiveName: `ミスディレクション`,
+      skillPassiveDescription: `ガラテアが壁張りつきを解除すると分身を残す。分身が破壊されるとクールダウンが発生する`,
+      skillUltimateName: `イリュージョン`,
+      skillUltimateDescription: `ガラテアがカードを3枚放ち、3体の分身を生成する。各分身にテレポートすることができる`,
+      subName: `subName`,
+      subDescription: `subDescription`,
+    },
+  },
+  characterTypes: {
+    Sentinel: 'センチネル',
+    Support: 'サポート',
+    Controller: 'コントローラー',
+    Duellist: 'デュエリスト',
+    Initiator: 'イニシエーター',
+  },
+  grenades: {
+    Flashbang: '閃光弹',
+    FragGrenade: 'フラググレネード',
+    HealingGrenade: '回復グレネード',
+    Interceptor: 'インターセプター',
+    SlowGrenade: '减速ボム',
+    SmokeBomb: '煙幕弾',
+    Alarm: '警報器',
+    WindstormGrenade: '風雷ボム',
+    SnowBall: '雪玉',
+  },
+  others: {
+    Bomb: 'Bomb',
+    BombA: 'Bomb A',
+    BombB: 'Bomb B',
+    BombC: 'Bomb C',
+    Focus: 'Focus',
+    Warning: 'Warning',
+    Flag: 'Flag',
+    Danger: 'Danger',
+  },
+  markbox: {
+    mark: 'マーク',
+    straightline: '直線',
+    arrowline: 'Arrow Line',
+    color: 'カラー',
+    undo: '戻す',
+    clear: '消去',
+    clearwarning: {
+      title: '全てのマークを消去しますか?',
+      content: 'この操作は元に戻せません',
+      ok: '確認',
+      cancel: 'キャンセル',
+      success: '全てのマークを消去しました',
+      failure: 'マークの削除に失敗しました',
+    },
+  },
+};

--- a/src/data/languages/zh_CN.tsx
+++ b/src/data/languages/zh_CN.tsx
@@ -1,515 +1,601 @@
-import { FaGithub } from "react-icons/fa";
-import { Languages } from "../../types/interface";
+import { FaGithub } from 'react-icons/fa';
+import { Languages } from '../../types/interface';
 
 export default {
-	language: Languages.zh_CN,
-	title: '卡拉彼丘地图助手',
-	announcement: "公告",
-	friendlink: "友情链接",
-	sitelist: "切换网站节点",
-	announcementdata: {
-		notshowntoday: "今日不再显示",
-		pin: {
-			title: "更新",
-			date: "2025.4.23",
-			summary: "添加了新地图和玛拉",
-			data: {}
-		},
-		history: []
-	},
-	friendlinkdata: {
-		classify: {
-			official: "官方",
-			wiki: "Wiki",
-			others: "其他"
-		},
-		official:
-			[{
-				name: "",
-				icon: <img style={{ height: "35px", filter: "brightness(1000%) drop-shadow(0 0 2px rgba(var(--semi-grey-7))" }} src='https://game.gtimg.cn/images/kq/m/web20230505/sec_ordlogo.png' />,
-				url: "https://klbq.qq.com/",
-			}, {
-				name: "",
-				icon: <img style={{ height: "22px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-9))" }} src='https://klbq-web-cms.strinova.com/prod/strinova_static/home_v12/img/icon/logo-white.png' />,
-				url: "https://www.strinova.com/",
-			}],
-		wiki:
-			[{
-				name: "",
-				icon: <img style={{ height: "32px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-9))" }} src='https://s2.loli.net/2024/10/01/NQTMvDZ5ah4omYR.png' />,
-				url: "https://wiki.biligame.com/klbq/",
-			}, {
-				name: "Strinovajp Wiki",
-				icon: <></>,
-				url: "https://www.strinovajp-wiki.jp/index.html",
-			}, {
-				name: "",
-				icon: <img style={{ height: "22px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))" }} src='https://s2.loli.net/2024/10/01/R4UxmBPGd2f8kQ7.webp' />,
-				url: "https://strinova.wiki.gg/wiki/Strinova_Wiki",
-			}, {
-				name: "Miraheze Meta",
-				icon: <></>,
-				url: "https://strinova.org/wiki/",
-			}, {
-				name: "日本語wiki",
-				icon: <img style={{ height: "28px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))", marginRight: "8px" }} src='https://w.atwiki.jp/common/_img/atwiki_logo_small.svg?t=741a51e81c8c8d5fe9627b874ecad193' />,
-				url: "https://w.atwiki.jp/calabiyau_jp/",
-			},],
-		others:
-			[{
-				name: "自建房助手",
-				icon: <img style={{ height: "35px", filter: "drop-shadow(0 0 2px rgba(var(--semi-grey-1))", marginRight: "8px" }} src='https://s2.loli.net/2024/10/01/pmYnw16rL2PQWBy.png' />,
-				url: "https://klbq.fsltech.cn/",
-			}],
-		contact: {
-			content: <div style={{ width: "100%", textAlign: "center" }}>
-				添加友链请联系 <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
-			</div>
-		}
-	},
-	sitelistdata: {
-		content: <>
-			<div>为了提供更快的访问速度以及减轻服务器压力，</div>
-			<div>我们开设了不同节点</div>
-		</>,
-		Global: [
-			{
-				icon: <><FaGithub style={{ color: "rgba(var(--semi-grey-9), 1)", fontSize: "20px", marginRight: "10px" }} /></>,
-				content: "Github Page",
-				url: "https://strinova.fsltech.cn/"
-			}
-		],
-		CN: [
-			// {
-			// 	icon: <></>,
-			// 	content: "腾讯云CDN -  上海 - 1",
-			// 	url: "https://sh-1.strinova.fsltech.cn/"
-			// },
-			// {
-			// 	icon: <></>,
-			// 	content: "腾讯云CDN - 香港 - 1",
-			// 	url: "https://hk-1.strinova.fsltech.cn/"
-			// }
-		],
-	},
-	supportusdata: {
-		content: <>
-			<div><strong>卡拉彼丘地图助手</strong>是一款开源应用，</div>
-			<div>因此你可以免费在 GPL-3.0 开源协议的范畴下使用本应用。</div>
-			<div>美术资料与部分UI版权归原作者与官方所有，</div>
-			<div>请咨询对应作者与官方授权！</div>
-			<br />
-			<div>但即便如此，你的赞助也可以给予开发者前进的动力，让这个项目变得更好。</div>
-			<div>无论你使用何种形式赞助，你都可以在<strong>卡拉彼丘地图助手</strong>的 GitHub 项目主页和网站展示您的信息（个人主页、公司主页、GitHub 资料页等）。</div>
-			<div>如需展示，请在留言中留下需要展示的内容或将内容连同赞助收据发送至 <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a></div>
-		</>,
-		global: "国际",
-		CN: "中国境内",
-		list: "赞助列表"
-	},
-	sidebar: {
-		attact: '进攻',
-		defense: '防守',
-		mapsetting: '地图设置',
-		character: '超弦体',
-		skill: '技能',
-		grenade: '战术道具',
-		other: '其他',
-		lineup: '战术道具点位',
-		skilllineup: '技能点位',
-		mobaisuperjump: '白墨超级跳点位',
-		bugpoint: 'Bug点位',
-		bugpointwarning: (
-			<div style={{ fontSize: '12px', textAlign: 'left' }}>
-				<div>这里列出的Bug点位仅用于警示作用，请勿在游戏中利于Bug！</div>
-				<div>在游戏中利用Bug导致被封禁等不良后果本站概不负责！</div>
-			</div>
-		),
-		learnmore: '了解更多',
-		supportus: '支持我们',
-		supportusContent: <></>
-	},
-	mapsetting: {
-		choosemap: '选择地图',
-		maps: {
-			WindyTown: '风曳镇',
-			SpaceLab: '空间实验室',
-			Khesmet: '科斯迷特',
-			EulerPort: '欧拉港口',
-			CauchyDistrict: '柯西街区',
-			Area88: '88区',
-			Base404: '404基地',
-			Ocarnus: '奥卡努斯'
-		},
-		TeamHighlight: '区分阵营',
-		TeamHighlightOptions: {
-			prepare: '准备阶段',
-			blank: '空白'
-		},
-		Landmarks: '点位标记'
-	},
-	lineupsetting: {
-		spotmark: '点位标记',
-		spotmarks: {
-			disable: '禁用',
-			available: '仅有效',
-			all: '全部'
-		}
-	},
-	skilllineupsetting: {
-		spotmark: '点位标记',
-		spotmarks: {
-			disable: '禁用',
-			available: '仅有效',
-			all: '全部'
-		}
-	},
-	mobaisuperjumpsetting: {
-		spotmark: '点位标记',
-		spotmarks: {
-			disable: '禁用',
-			available: '仅有效',
-			all: '全部'
-		}
-	},
-	bugpointsetting: {
-		spotmark: '点位标记',
-		spotmarks: {
-			disable: '禁用',
-			available: '仅有效',
-			all: '全部'
-		}
-	},
-	factions: {
-		PUS: '欧泊',
-		TheScissors: '剪刀手',
-		Urbino: '乌尔比诺'
-	},
-	characters: {
-		PUS: {
-			Michele: '米雪儿·李',
-			Nobunaga: '信',
-			Kokona: '心夏',
-			Yvette: '伊薇特',
-			Flavia: '芙拉薇娅',
-			Yugiri: "忧雾",
-			Leona: "雷欧娜"
-		},
-		TheScissors: {
-			Ming: '明',
-			Lawine: '拉薇',
-			Meredith: '梅瑞狄斯',
-			Reiichi: '令',
-			Kanami: '香奈美',
-			Eika: '艾卡',
-			Fragrans: '珐格兰丝',
-			Mara:'玛拉'
-		},
-		Urbino: {
-			Celestia: '星绘',
-			Audrey: '奥黛丽',
-			Maddelena: '白墨',
-			Fuchsia: '玛德蕾娜',
-			BaiMo: '绯莎',
-			Galatea: '加拉蒂亚'
-		}
-	},
-	characterInfo: {
-		Michele: {
-			Name: "米雪儿·李",
-			Type: "守护",
-			skillActiveName: `喵喵卫士`,
-			skillActiveDescription: `米雪儿投掷可附着在建筑表面的喵喵卫士，喵喵卫士将自动攻击一定范围内的敌方角色，并使其减速。`,
-			skillPassiveName: `猫踪喵迹`,
-			skillPassiveDescription: `米雪儿被武器直接命中时，可以使造成伤害的敌人进入透视状态。`,
-			skillUltimateName: `火力大喵`,
-			skillUltimateDescription: `米雪儿部署一架强大火力的火力炮艇，火力炮艇将自动攻击一定范围内的敌方角色。`,
-			subName: `破法喵喵`,
-			subDescription: `米雪儿抛出能附着在建筑表面的破法喵喵，破法喵喵可被米雪儿主动激活，并在短暂延迟后对周围敌人造成沉默效果。`,
-		},
-		Nobunaga: {
-			Name: "信",
-			Type: "守护",
-			skillActiveName: `守望之眼`,
-			skillActiveDescription: `信可布置至多两个守望之眼，在守望之眼的范围内将获得射速和人机工效提升并回复护甲；两个守望之眼互相连接时，增益效果提升。`,
-			skillPassiveName: `致盲脉冲`,
-			skillPassiveDescription: `开镜状态下的信开始积蓄能量，能量续满后，他的射击将使敌人在开镜状态下丢失准星。`,
-			skillUltimateName: `脉冲过载`,
-			skillUltimateDescription: `信原地部署一个向四周不断发射脉冲波的脉冲装置，被脉冲波命中的敌人将被透视给全体队友且进入一段时间的沉默状态。`,
-			subName: `脉冲地雷`,
-			subDescription: `信向目标方向投出一个地雷，地雷部署完毕后会进入敌方靠近后才会显形的隐身状态，当地雷检测到敌人后会引爆并对范围内的敌人造成持续伤害。`,
-		},
-		Kokona: {
-			Name: "心夏",
-			Type: "支援",
-			skillActiveName: `治疗无人机`,
-			skillActiveDescription: `心夏选择自己或一个友方角色为目标生成—个治疗无人机，无人机可以为被释放目标回复护甲，并给无人机周围所有友方目标回复生命值。`,
-			skillPassiveName: `急速救援`,
-			skillPassiveDescription: `心夏会在未受击时缓慢回复自身生命值，同时在救援友方角色时，心夏会放出援护无人机自动扶起队友。`,
-			skillUltimateName: `卡丘重塑`,
-			skillUltimateDescription: `心夏选择一个阵亡的友方角色，将其复活在自己附近。`,
-			subName: `医疗站点`,
-			subDescription: `心夏可以定点部署一个治疗无人机，无人机会制造一大片治疗场，处在区域内的队友会持续恢复生命值，该恢复效果不会被伤害中断。`,
-		},
-		Yvette: {
-			Name: "伊薇特",
-			Type: "控场",
-			skillActiveName: `熊熊出击`,
-			skillActiveDescription: `伊薇特召出战术熊，熊可以冲撞，撞到障碍物或是再次按下左键会在地面上留下冰面。冰面附带打滑和易伤效果。`,
-			skillPassiveName: `皑皑藏雪`,
-			skillPassiveDescription: `伊薇特站立不动一段时间后，会进入迷彩状态，远处的敌人看不见伊薇特，当愈发靠近时才会慢慢显示其轮廓。`,
-			skillUltimateName: `爽爽霜风`,
-			skillUltimateDescription: `伊薇特召唤出一只巨大的冰霜熊，分三段展开极寒领域，敌人在此将受到打滑和易伤，降低射速及人机工效的效果。`,
-			subName: `坚坚冰柱`,
-			subDescription: `伊薇特可以投掷出一个冰球，冰球落在地面后会在落点生成一块巨大的冰柱，冰柱拥有高额生命值且会阻挡敌我双方的子弹，站在冰柱附近的敌人会受到打滑和易伤的效果，冰柱无法在有角色或召唤物的地方生成。`,
-		},
-		Flavia: {
-			Name: "芙拉薇娅",
-			Type: "决斗",
-			skillActiveName: `致幻魅影`,
-			skillActiveDescription: `芙拉薇娅召唤幻蝶短时间跟随自己，期间受到攻击损失生命值时进入短时间的无敌状态并原地生成一个致幻球。致幻球限制敌方视野且可被击碎。`,
-			skillPassiveName: `周生复始`,
-			skillPassiveDescription: `芙拉薇娅累计受到少量伤害时会减少主动技能的冷却时间；累计受到大量伤害时会获得临时绝招点数，通过此方式获得的绝招点数当前回合有效。`,
-			skillUltimateName: `幻梦化蝶`,
-			skillUltimateDescription: `芙拉薇娅以自身为中心释放致幻领域，领域内的敌方单位造成致命伤害时，芙拉薇娅会化身为蝴蝶，短时间后重塑身体，继续战斗。领域外敌方无视重塑规则但仅在被攻击时可视芙拉薇娅。`,
-			subName: `遁入幻境`,
-			subDescription: `芙拉薇娅引动弦能，以自身为中心生成遮蔽视野的烟雾。芙拉薇娅可以在化蝶状态使用该技能，这样做将立即解除化蝶状态。`,
-		},
-		Yugiri: {
-			Name: "忧雾",
-			Type: "控场",
-			skillActiveName: `蚀甲毒雾`,
-			skillActiveDescription: `布置一个蜗牛装置，激活后可产生球形毒雾，临时腐蚀附近敌方角色的护甲。`,
-			skillPassiveName: `毒雾爆发`,
-			skillPassiveDescription: `使用主武器对敌方角色造成一定量的生命值伤害后，会引爆敌人体内的腐蚀性毒素，临时腐蚀附近敌方角色的护甲。`,
-			skillUltimateName: `凌毒侵蚀`,
-			skillUltimateDescription: `召唤大范围的毒雾向前方缓慢推进，腐蚀范围内敌方角色的护甲上限。`,
-			subName: `腐蚀溶液`,
-			subDescription: `忧雾向目标区域投掷毒液装置，毒液装置落地时会爆开并制造一片腐蚀区域，对区域内的敌人造成伤害与减速效果，弦化状态的敌人受到额外伤害。`,
-		},
-		Leona: {
-			Name: "蕾欧娜",
-			Type: "守护",
-			skillActiveName: `弦能掩墙`,
-			skillActiveDescription: `蕾欧娜可以在指定平地或斜坡生成两种角度的正方形建筑块。方块生成会消耗技能点数及弦能条。方块最多同时存在16个。`,
-			skillPassiveName: `劳逸结合`,
-			skillPassiveDescription: `蕾欧娜在弦化状态会持续恢复弦能，当弦能高于50%时，提高自身移动速度；低于50%时，逐渐恢复自身护甲。`,
-			skillUltimateName: `纯净坚城`,
-			skillUltimateDescription: `蕾欧娜充满弦能条，场上已存在方块和技能持续期间生成的方块永久变透明，透明方块将不再阻挡通路与友方子弹。`,
-			subName: `防弹护窗`,
-			subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
-		},
-		Ming: {
-			Name: "明",
-			Type: "决斗",
-			skillActiveName: `破甲电球`,
-			skillActiveDescription: `明发射一个电球，其达到最大距离、碰到敌方超弦体时会自动引爆，也可通过手动再次按下技能键后主动引爆。电球会破坏范围内所有敌方单位（包含召唤物）的护甲并造成减速。明进入电场将提升移动速度。`,
-			skillPassiveName: `吸能赋甲`,
-			skillPassiveDescription: `明使用枪械和主动技能对敌方护甲或护盾造成伤害时，自己的护甲将得到基于该伤害量的回复。绝招持续时间内，被动会回复临时护甲并增加回复量。`,
-			skillUltimateName: `强雷铸甲`,
-			skillUltimateDescription: `明获得临时护甲并使自己的射击附带可叠加的减速效果。明使用枪械和主动技能对敌人的护甲造成伤害时，可延长该技能持续时间并回复临时护甲。`,
-			subName: `爆闪电球`,
-			subDescription: `明可以发射一个闪光电球，再次按下技能键后或是到达最大飞行时间后引爆，并对周围所有敌人造成致盲效果，引爆前有一段延迟，延迟期间内闪光电球可以被摧毁。`,
-		},
-		Lawine: {
-			Name: "拉薇",
-			Type: "先锋",
-			skillActiveName: `寻影猎刃`,
-			skillActiveDescription: `拉薇投掷脉冲刀，制造一个磁力场，将一定范围内的敌方单位暴露给拉薇及其队友，脉冲刀每次扫描探测不到敌人时会立刻消失，最多扫描三次。`,
-			skillPassiveName: `曝影显踪`,
-			skillPassiveDescription: `拉薇主武器命中敌方单位时，会将其短暂透视给自己。`,
-			skillUltimateName: `遁影藏踪`,
-			skillUltimateDescription: `拉薇于自身正前方生成一片矩形磁场。进入磁场时，拉薇将进入隐身状态。隐身状态下的拉薇无法射击。`,
-			subName: `闪影猎刃`,
-			subDescription: `拉薇可以扔出一把闪光脉冲刀，脉冲刀插在障碍物上后引爆，并对周围所有敌人造成致盲效果，引爆前有一段延迟，延迟期间内飞刀可以被摧毁。`,
-		},
-		Meredith: {
-			Name: "梅瑞狄斯",
-			Type: "控场",
-			skillActiveName: `金沙热浪`,
-			skillActiveDescription: `梅瑞狄斯打出一颗弦能球体，于落点处创造一片黄沙领域，降低敌方角色移速和人机工效一段时间并暂时削减其生命值。`,
-			skillPassiveName: `时零沙环`,
-			skillPassiveDescription: `滞空状态下，当梅瑞狄斯进入技能瞄准、武器瞄准或者战术瞄准的状态时，自身的下落速度会被降低。`,
-			skillUltimateName: `流沙大葬`,
-			skillUltimateDescription: `梅瑞狄斯投掷出一个能制造巨大沙暴领域的金字塔。沙暴领域可以遮蔽视野，并暂时削减敌方角色生命值。`,
-			subName: `盲眼迷沙`,
-			subDescription: `梅瑞狄斯向目标方向发射弦能球体，于落点处创造一片完全遮蔽视野的环状黄沙领域。`,
-		},
-		Reiichi: {
-			Name: "令",
-			Type: "控场",
-			skillActiveName: `破晓帷幕`,
-			skillActiveDescription: `令使用自己的伞制造出一堵可以纵向释放或者横向释放的弦能光幕，光幕会遮蔽视野。`,
-			skillPassiveName: `黎明洞悉`,
-			skillPassiveDescription: `在保持开镜状态时，令每一段时间会扫描一遍前方敌人及其召唤物，使其透视，仅令可见。`,
-			skillUltimateName: `庇护圣屏`,
-			skillUltimateDescription: `立即刷新主动技能，在持续时间内增强光幕，使其能够格挡所有来自敌方角色的子弹。`,
-			subName: `圣屏突进`,
-			subDescription: `令释放一个可以向前推进的光幕，该光幕在准备释放阶段能够设置最终落点。`,
-		},
-		Kanami: {
-			Name: "香奈美",
-			Type: "先锋",
-			skillActiveName: `旋律回响`,
-			skillActiveDescription: `香奈美可以用枪射出声呐片，声呐片会释放出声波实时探查其前方180°一定范围内无建筑障碍物遮挡的敌人，被发现的敌人会暴露给香奈美及其队友。`,
-			skillPassiveName: `交响爆音`,
-			skillPassiveDescription: `香奈美的主武器发射子弹之后，会以子弹落点范围产生一个圆形音波区，处在音波区内的敌人信息会被暴露给香奈美自己。`,
-			skillUltimateName: `演出开始`,
-			skillUltimateDescription: `香奈美在战场内展开舞台，舞台展开后开始播放音乐，所有在舞台一定范围内的敌人都会被歌声吸引、减速、丢失准星的同时还会被晕眩，降低射速。`,
-			subName: `律动旋风`,
-			subDescription: `香奈美可以扔出一个迷你音响，制造一大片声风场区域，该风场会将所有进入风场内的角色吹起。在被吹起期间，敌方角色受到晕眩效果，友方角色获得移速提升效果，上述效果在离开风场区域后还会持续一段时间。`,
-		},
-		Eika: {
-			Name: "艾卡",
-			Type: "决斗",
-			skillActiveName: `炼狱牢笼`,
-			skillActiveDescription: `在面前生成一个球形火牢，敌人穿过牢壁受到火焰伤害，牢内没敌人时提前结束。艾卡在火牢内，主武器对内部敌人造成额外火焰伤害。消耗100热量所获增益：牢壁的伤害更高。`,
-			skillPassiveName: `日珥蓄火`,
-			skillPassiveDescription: `每次射击命中敌人会积攒热量，最多100值。满热时对弦化敌人造伤能力增强。满热下，其他技能可以消耗热量获得强化。`,
-			skillUltimateName: `烈焰风暴`,
-			skillUltimateDescription: `本回合内最多丢出3道烈焰风暴，吹飞敌人并造成火焰伤害。每发消耗100热量所获增益：风暴更大，伤害更高，且敌人高亮。`,
-			subName: `爆焰热弹`,
-			subDescription: `艾卡可以快速丢出一枚爆焰火球，火球落地时造成伤害，对弦化状态的敌人造成额外伤害。消耗100热量所获增益：提升伤害并附带减速效果。`,
-		},
-		Fragrans: {
-			Name: "珐格兰丝",
-			Type: "支援",
-			skillActiveName: `活力芬芳`,
-			skillActiveDescription: `珐格兰丝可以释放两种有限数量的香水。释放后会以自己为中心创造香氛区域，区域内己方会获得射速或移速提升，香氛效果会随着时间推移逐渐减弱，最终消失。`,
-			skillPassiveName: `复苏芳香`,
-			skillPassiveDescription: `珐格兰丝会散发淡淡的恢复香氛，附近的队友和自己都会缓慢恢复生命值。`,
-			skillUltimateName: `激昂芬芳`,
-			skillUltimateDescription: `珐格兰丝会以自己为中心制造强烈香氛区域，区域内友军会获得高额射速、移速提升和生命值恢复，该效果不会衰减且生命值恢复不会被伤害中断，释放期间珐格兰丝无法使用武器，但会获得大幅减伤。`,
-			subName: `香语众氛`,
-			subDescription: `珐格兰丝投掷出一瓶治疗香水，治疗香水触碰到障碍物时爆炸生效，制造一片回复生命区域，进入区域内的人会被赋予一段缓慢回复生命效果，即使离开区域也会持续一段时间。`,
-		},
-		Mara: {
-			Name: "玛拉",
-			Type: "决斗",
-			skillActiveName: `直击灵魂`,
-			skillActiveDescription: `向前施放鬼手，命中最近一名非倒地的敌方角色，使其灵魂出窍和减速。仅玛拉可通过武器攻击此灵魂球，对灵魂球造成伤害时，基于此一定比例给予敌人忽视护甲的血量伤害。敌人侧身或者飘飞时附着的灵魂球会缩小。`,
-			skillPassiveName: `摄魂侵魄`,
-			skillPassiveDescription: `玛拉使用武器对非满血敌方角色造成伤害时，会基于此伤害的一定比例恢复生命值以及对敌方角色造成额外忽视护甲的生命值伤害。此恢复效果同样适应于主动技能的灵魂球传导伤害。`,
-			skillUltimateName: `死神来了`,
-			skillUltimateDescription: `选择离自己最近的一名敌方角色施加死亡印记：该敌人会被沉默，及仅玛拉可视的暴露状态。在此期间当玛拉参与击倒或击杀此角色，此印记会传导给一定范围内离玛拉最近的非倒地敌人，并重新计时。此效果会持续到玛拉死亡或者时间结束。`,
-			subName: `亡灵漫步`,
-			subDescription: `开启后，玛拉弦化时会进入特殊隐身状态，当敌人逐渐靠近时玛拉才会显形；且弦化移速增加；在终极技能触发时，显形的最远距离会进一步缩小。`,
-		},
-		Celestia: {
-			Name: "星绘",
-			Type: "支援",
-			skillActiveName: `守护星芒`,
-			skillActiveDescription: `星绘选择一个友方角色，投掷流星弦能，赋予其临时护甲。之后流星弦能将返回星绘身边，赋予星绘临时护甲。`,
-			skillPassiveName: `星弦甲生`,
-			skillPassiveDescription: `星绘周围有友方角色时，可缓慢恢复该角色与自身的护甲值。`,
-			skillUltimateName: `星空之门`,
-			skillUltimateDescription: `星绘选择一个友方角色，为该队友和自身提供临时护甲值，并开始蓄能。蓄能完毕后，星绘将传送到该角色身边，蓄能期间按下大招键可取消传送（不取消护甲增益）。`,
-			subName: `塑甲星芒`,
-			subDescription: `星绘向目标区域掷出星芒，星芒触碰到障碍物时爆炸生效，制造一片回复护甲区域，进入区域内的人会被赋予一段缓慢回复护甲效果，即使离开区域也会持续一段时间。`,
-		},
-		Audrey: {
-			Name: "奥黛丽",
-			Type: "守护",
-			skillActiveName: `重火倾泄`,
-			skillActiveDescription: `进入架设状态，大幅提升射速，无后坐力，连续射击不需更换弹匣。若奥黛丽的连续射击时间过长，便会进入枪口过热状态无法射击。`,
-			skillPassiveName: `皇家盾牌`,
-			skillPassiveDescription: `奥黛丽进入架枪模式或进入开镜模式时，召唤护盾守护自身正面，且架枪模式下会获得额外护盾最大值。`,
-			skillUltimateName: `狂轰滥炸`,
-			skillUltimateDescription: `奥黛丽架设一把榴弹发射器，可发射六枚榴弹炮。榴弹炮爆炸后会分裂成弹跳炸弹，弹跳炸弹爆炸时将于地面生成火海。`,
-			subName: `警报雷达`,
-			subDescription: `奥黛丽丢出一个警报雷达，雷达落地后展开并对周围持续进行扫描，扫描到敌人时提示敌人的数量并对敌人施加短暂透视效果。`,
-		},
-		Maddelena: {
-			Name: "玛德蕾娜",
-			Type: "控场",
-			skillActiveName: `颜料束缚`,
-			skillActiveDescription: `玛德蕾娜发射一滩颜料，经过这滩颜料的敌人将被减速、弦化禁止并暴露脚印。`,
-			skillPassiveName: `颜料脚印`,
-			skillPassiveDescription: `玛德蕾娜使用主武器命中敌方角色时，可使敌方角色减速并暴露脚印。`,
-			skillUltimateName: `颜料泡泡`,
-			skillUltimateDescription: `玛德蕾娜发射巨大泡泡，泡泡内的敌人将被禁止弦化且暴露脚印。泡泡爆炸后将对爆炸范围内的敌人施加额外的减速和易伤效果。`,
-			subName: `颜料泡涌`,
-			subDescription: `玛德蕾娜向前方发射颜料泡，再次按下技能键后颜料泡会停留在原地，颜料泡会对碰到的敌人造成减速和弦化禁止效果。`,
-		},
-		Fuchsia: {
-			Name: "绯莎",
-			Type: "决斗",
-			skillActiveName: `残息追踪`,
-			skillActiveDescription: `对周围敌人感知，满血敌人被短暂透视，生命值不满则被持续透视，上述效果仅自己可视。感应到敌人将增加绯莎的移动速度。`,
-			skillPassiveName: `以战养战`,
-			skillPassiveDescription: `绯莎参与击破时，死亡的敌人将原地掉落能量晶体。绯莎可以靠近并吸收能量晶体，回复自身生命值。绯莎第一次吸取能量晶体时可增加自身生命值上限。`,
-			skillUltimateName: `浴血狂戮`,
-			skillUltimateDescription: `绯莎大幅度提升自身的射速和人机工效，并使得主动技能可令视野内敌人高亮。吸收能量晶体将延长该效果持续时间。`,
-			subName: `猩红猛冲`,
-			subDescription: `绯莎消耗当前一定百分比生命值，获得移速提升效果，持续一段时间。`,
-		},
-		BaiMo: {
-			Name: "白墨",
-			Type: "决斗",
-			skillActiveName: `炫空斗舞`,
-			skillActiveDescription: `白墨进入弦化状态，向前翻转跳跃贴近敌人，并为主武器自动补充子弹。白墨参与击破将刷新冷却。`,
-			skillPassiveName: `嘻哈嘣彩`,
-			skillPassiveDescription: `白墨的主武器单次射击命中敌人造成至少50点伤害后，使其弦化禁止。`,
-			skillUltimateName: `重返街头`,
-			skillUltimateDescription: `白墨原地放置一个重生信标，死亡或倒地时可以立即在信标处重生。白墨可以选择主动返回信标，并回复全部生命值。`,
-			subName: `爆炸涂鸦`,
-			subDescription: `白墨快速向前投掷出颜料罐，颜料罐爆炸时对周围敌人造成禁止弦化效果。`,
-		},
-		Galatea: {
-			Name: "加拉蒂亚",
-			Type: "先锋",
-			skillActiveName: `飞牌瞬闪`,
-			skillActiveDescription: `加拉蒂亚释放出一张卡牌以弧线飞出，卡牌碰到地面、墙面时会生成分身，按下交互键可以传送到分身位置。`,
-			skillPassiveName: `欺诈牌影`,
-			skillPassiveDescription: `当加拉蒂亚脱离墙面时，会在贴墙位置留下一个分身，每次下墙都会重新生成分身，当分身受伤时该被动进入冷却。加拉蒂亚的每一个分身在生成时都可以短暂探测周围无建筑障碍物遮挡的敌人给加拉蒂亚及全体友方，攻击分身的敌人也会被暂时暴露。`,
-			skillUltimateName: `牌影戏法`,
-			skillUltimateDescription: `加拉蒂亚朝前方随意投出大量卡牌，每一个卡牌都可以生成分身并让加拉蒂亚传送。`,
-			subName: `致盲牌影`,
-			subDescription: `加拉蒂亚可以释放一个特殊的卡片分身，加拉蒂亚无法传送到该分身的位置，该分身被敌人摧毁时，会对周围所有敌人造成闪光效果。`,
-		}
-	},
-	characterTypes: {
-		Sentinel: '守护',
-		Support: '支援',
-		Controller: '控场',
-		Duellist: '决斗',
-		Initiator: '先锋'
-	},
-	grenades: {
-		Flashbang: '闪光弹',
-		FragGrenade: '手雷',
-		HealingGrenade: '治疗雷',
-		Interceptor: '拦截者',
-		SlowGrenade: '减速雷',
-		SmokeBomb: '烟雾弹',
-		Alarm: '警报器',
-		WindstormGrenade: '风场雷',
-		SnowBall: '雪球'
-	},
-	others: {
-		Bomb: 'Bomb',
-		BombA: 'Bomb A',
-		BombB: 'Bomb B',
-		BombC: 'Bomb C',
-		Focus: 'Focus',
-		Warning: 'Warning',
-		Flag: 'Flag',
-		Danger: 'Danger',
-	},
-	markbox: {
-		mark: '画笔',
-		straightline: '直线',
-		arrowline: '箭头',
-		color: '颜色',
-		undo: '撤销',
-		clear: '清空',
-		clearwarning: {
-			title: '确认清除所有笔迹？',
-			content: '此操作不可撤销',
-			ok: '确认',
-			cancel: '取消',
-			success: '已清除所有笔迹',
-			failure: '清除笔迹失败'
-		}
-	}
-}
+  language: Languages.zh_CN,
+  title: '卡拉彼丘地图助手',
+  announcement: '公告',
+  friendlink: '友情链接',
+  sitelist: '切换网站节点',
+  announcementdata: {
+    notshowntoday: '今日不再显示',
+    pin: {
+      title: '更新',
+      date: '2025.4.23',
+      summary: '添加了新地图和玛拉',
+      data: {},
+    },
+    history: [],
+  },
+  friendlinkdata: {
+    classify: {
+      official: '官方',
+      wiki: 'Wiki',
+      others: '其他',
+    },
+    official: [
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '35px',
+              filter:
+                'brightness(1000%) drop-shadow(0 0 2px rgba(var(--semi-grey-7))',
+            }}
+            src='https://game.gtimg.cn/images/kq/m/web20230505/sec_ordlogo.png'
+          />
+        ),
+        url: 'https://klbq.qq.com/',
+      },
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '22px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-9))',
+            }}
+            src='https://klbq-web-cms.strinova.com/prod/strinova_static/home_v12/img/icon/logo-white.png'
+          />
+        ),
+        url: 'https://www.strinova.com/',
+      },
+    ],
+    wiki: [
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '32px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-9))',
+            }}
+            src='https://s2.loli.net/2024/10/01/NQTMvDZ5ah4omYR.png'
+          />
+        ),
+        url: 'https://wiki.biligame.com/klbq/',
+      },
+      {
+        name: 'Strinovajp Wiki',
+        icon: <></>,
+        url: 'https://www.strinovajp-wiki.jp/index.html',
+      },
+      {
+        name: '',
+        icon: (
+          <img
+            style={{
+              height: '22px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+            }}
+            src='https://s2.loli.net/2024/10/01/R4UxmBPGd2f8kQ7.webp'
+          />
+        ),
+        url: 'https://strinova.wiki.gg/wiki/Strinova_Wiki',
+      },
+      {
+        name: 'Miraheze Meta',
+        icon: <></>,
+        url: 'https://strinova.org/wiki/',
+      },
+      {
+        name: '日本語wiki',
+        icon: (
+          <img
+            style={{
+              height: '28px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+              marginRight: '8px',
+            }}
+            src='https://w.atwiki.jp/common/_img/atwiki_logo_small.svg?t=741a51e81c8c8d5fe9627b874ecad193'
+          />
+        ),
+        url: 'https://w.atwiki.jp/calabiyau_jp/',
+      },
+    ],
+    others: [
+      {
+        name: '自建房助手',
+        icon: (
+          <img
+            style={{
+              height: '35px',
+              filter: 'drop-shadow(0 0 2px rgba(var(--semi-grey-1))',
+              marginRight: '8px',
+            }}
+            src='https://s2.loli.net/2024/10/01/pmYnw16rL2PQWBy.png'
+          />
+        ),
+        url: 'https://klbq.fsltech.cn/',
+      },
+    ],
+    contact: {
+      content: (
+        <div style={{ width: '100%', textAlign: 'center' }}>
+          添加友链请联系 <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
+        </div>
+      ),
+    },
+  },
+  sitelistdata: {
+    content: (
+      <>
+        <div>为了提供更快的访问速度以及减轻服务器压力，</div>
+        <div>我们开设了不同节点</div>
+      </>
+    ),
+    Global: [
+      {
+        icon: (
+          <>
+            <FaGithub
+              style={{
+                color: 'rgba(var(--semi-grey-9), 1)',
+                fontSize: '20px',
+                marginRight: '10px',
+              }}
+            />
+          </>
+        ),
+        content: 'Github Page',
+        url: 'https://strinova.fsltech.cn/',
+      },
+    ],
+    CN: [
+      // {
+      // 	icon: <></>,
+      // 	content: "腾讯云CDN -  上海 - 1",
+      // 	url: "https://sh-1.strinova.fsltech.cn/"
+      // },
+      // {
+      // 	icon: <></>,
+      // 	content: "腾讯云CDN - 香港 - 1",
+      // 	url: "https://hk-1.strinova.fsltech.cn/"
+      // }
+    ],
+  },
+  supportusdata: {
+    content: (
+      <>
+        <div>
+          <strong>卡拉彼丘地图助手</strong>是一款开源应用，
+        </div>
+        <div>因此你可以免费在 GPL-3.0 开源协议的范畴下使用本应用。</div>
+        <div>美术资料与部分UI版权归原作者与官方所有，</div>
+        <div>请咨询对应作者与官方授权！</div>
+        <br />
+        <div>
+          但即便如此，你的赞助也可以给予开发者前进的动力，让这个项目变得更好。
+        </div>
+        <div>
+          无论你使用何种形式赞助，你都可以在<strong>卡拉彼丘地图助手</strong>的
+          GitHub 项目主页和网站展示您的信息（个人主页、公司主页、GitHub
+          资料页等）。
+        </div>
+        <div>
+          如需展示，请在留言中留下需要展示的内容或将内容连同赞助收据发送至{' '}
+          <a href='mailto:fsltech@email.cn'>fsltech@email.cn</a>
+        </div>
+      </>
+    ),
+    global: '国际',
+    CN: '中国境内',
+    list: '赞助列表',
+  },
+  sidebar: {
+    attact: '进攻',
+    defense: '防守',
+    mapsetting: '地图设置',
+    character: '超弦体',
+    skill: '技能',
+    grenade: '战术道具',
+    other: '其他',
+    lineup: '战术道具点位',
+    skilllineup: '技能点位',
+    mobaisuperjump: '白墨超级跳点位',
+    bugpoint: 'Bug点位',
+    bugpointwarning: (
+      <div style={{ fontSize: '12px', textAlign: 'left' }}>
+        <div>这里列出的Bug点位仅用于警示作用，请勿在游戏中利于Bug！</div>
+        <div>在游戏中利用Bug导致被封禁等不良后果本站概不负责！</div>
+      </div>
+    ),
+    learnmore: '了解更多',
+    supportus: '支持我们',
+    supportusContent: <></>,
+  },
+  mapsetting: {
+    choosemap: '选择地图',
+    maps: {
+      WindyTown: '风曳镇',
+      SpaceLab: '空间实验室',
+      Khesmet: '科斯迷特',
+      EulerPort: '欧拉港口',
+      CauchyDistrict: '柯西街区',
+      Area88: '88区',
+      Base404: '404基地',
+      Ocarnus: '奥卡努斯',
+    },
+    TeamHighlight: '区分阵营',
+    TeamHighlightOptions: {
+      prepare: '准备阶段',
+      blank: '空白',
+    },
+    Landmarks: '点位标记',
+  },
+  lineupsetting: {
+    spotmark: '点位标记',
+    spotmarks: {
+      disable: '禁用',
+      available: '仅有效',
+      all: '全部',
+    },
+  },
+  skilllineupsetting: {
+    spotmark: '点位标记',
+    spotmarks: {
+      disable: '禁用',
+      available: '仅有效',
+      all: '全部',
+    },
+  },
+  mobaisuperjumpsetting: {
+    spotmark: '点位标记',
+    spotmarks: {
+      disable: '禁用',
+      available: '仅有效',
+      all: '全部',
+    },
+  },
+  bugpointsetting: {
+    spotmark: '点位标记',
+    spotmarks: {
+      disable: '禁用',
+      available: '仅有效',
+      all: '全部',
+    },
+  },
+  factions: {
+    PUS: '欧泊',
+    TheScissors: '剪刀手',
+    Urbino: '乌尔比诺',
+  },
+  characters: {
+    PUS: {
+      Michele: '米雪儿·李',
+      Nobunaga: '信',
+      Kokona: '心夏',
+      Yvette: '伊薇特',
+      Flavia: '芙拉薇娅',
+      Yugiri: '忧雾',
+      Leona: '雷欧娜',
+    },
+    TheScissors: {
+      Ming: '明',
+      Lawine: '拉薇',
+      Meredith: '梅瑞狄斯',
+      Reiichi: '令',
+      Kanami: '香奈美',
+      Eika: '艾卡',
+      Fragrans: '珐格兰丝',
+      Mara: '玛拉',
+    },
+    Urbino: {
+      Celestia: '星绘',
+      Audrey: '奥黛丽',
+      Maddelena: '白墨',
+      Fuchsia: '玛德蕾娜',
+      BaiMo: '绯莎',
+      Galatea: '加拉蒂亚',
+    },
+  },
+  characterInfo: {
+    Michele: {
+      Name: '米雪儿·李',
+      Type: '守护',
+      skillActiveName: `喵喵卫士`,
+      skillActiveDescription: `米雪儿投掷可附着在建筑表面的喵喵卫士，喵喵卫士将自动攻击一定范围内的敌方角色，并使其减速。`,
+      skillPassiveName: `猫踪喵迹`,
+      skillPassiveDescription: `米雪儿被武器直接命中时，可以使造成伤害的敌人进入透视状态。`,
+      skillUltimateName: `火力大喵`,
+      skillUltimateDescription: `米雪儿部署一架强大火力的火力炮艇，火力炮艇将自动攻击一定范围内的敌方角色。`,
+      subName: `破法喵喵`,
+      subDescription: `米雪儿抛出能附着在建筑表面的破法喵喵，破法喵喵可被米雪儿主动激活，并在短暂延迟后对周围敌人造成沉默效果。`,
+    },
+    Nobunaga: {
+      Name: '信',
+      Type: '守护',
+      skillActiveName: `守望之眼`,
+      skillActiveDescription: `信可布置至多两个守望之眼，在守望之眼的范围内将获得射速和人机工效提升并回复护甲；两个守望之眼互相连接时，增益效果提升。`,
+      skillPassiveName: `致盲脉冲`,
+      skillPassiveDescription: `开镜状态下的信开始积蓄能量，能量续满后，他的射击将使敌人在开镜状态下丢失准星。`,
+      skillUltimateName: `脉冲过载`,
+      skillUltimateDescription: `信原地部署一个向四周不断发射脉冲波的脉冲装置，被脉冲波命中的敌人将被透视给全体队友且进入一段时间的沉默状态。`,
+      subName: `脉冲地雷`,
+      subDescription: `信向目标方向投出一个地雷，地雷部署完毕后会进入敌方靠近后才会显形的隐身状态，当地雷检测到敌人后会引爆并对范围内的敌人造成持续伤害。`,
+    },
+    Kokona: {
+      Name: '心夏',
+      Type: '支援',
+      skillActiveName: `治疗无人机`,
+      skillActiveDescription: `心夏选择自己或一个友方角色为目标生成—个治疗无人机，无人机可以为被释放目标回复护甲，并给无人机周围所有友方目标回复生命值。`,
+      skillPassiveName: `急速救援`,
+      skillPassiveDescription: `心夏会在未受击时缓慢回复自身生命值，同时在救援友方角色时，心夏会放出援护无人机自动扶起队友。`,
+      skillUltimateName: `卡丘重塑`,
+      skillUltimateDescription: `心夏选择一个阵亡的友方角色，将其复活在自己附近。`,
+      subName: `医疗站点`,
+      subDescription: `心夏可以定点部署一个治疗无人机，无人机会制造一大片治疗场，处在区域内的队友会持续恢复生命值，该恢复效果不会被伤害中断。`,
+    },
+    Yvette: {
+      Name: '伊薇特',
+      Type: '控场',
+      skillActiveName: `熊熊出击`,
+      skillActiveDescription: `伊薇特召出战术熊，熊可以冲撞，撞到障碍物或是再次按下左键会在地面上留下冰面。冰面附带打滑和易伤效果。`,
+      skillPassiveName: `皑皑藏雪`,
+      skillPassiveDescription: `伊薇特站立不动一段时间后，会进入迷彩状态，远处的敌人看不见伊薇特，当愈发靠近时才会慢慢显示其轮廓。`,
+      skillUltimateName: `爽爽霜风`,
+      skillUltimateDescription: `伊薇特召唤出一只巨大的冰霜熊，分三段展开极寒领域，敌人在此将受到打滑和易伤，降低射速及人机工效的效果。`,
+      subName: `坚坚冰柱`,
+      subDescription: `伊薇特可以投掷出一个冰球，冰球落在地面后会在落点生成一块巨大的冰柱，冰柱拥有高额生命值且会阻挡敌我双方的子弹，站在冰柱附近的敌人会受到打滑和易伤的效果，冰柱无法在有角色或召唤物的地方生成。`,
+    },
+    Flavia: {
+      Name: '芙拉薇娅',
+      Type: '决斗',
+      skillActiveName: `致幻魅影`,
+      skillActiveDescription: `芙拉薇娅召唤幻蝶短时间跟随自己，期间受到攻击损失生命值时进入短时间的无敌状态并原地生成一个致幻球。致幻球限制敌方视野且可被击碎。`,
+      skillPassiveName: `周生复始`,
+      skillPassiveDescription: `芙拉薇娅累计受到少量伤害时会减少主动技能的冷却时间；累计受到大量伤害时会获得临时绝招点数，通过此方式获得的绝招点数当前回合有效。`,
+      skillUltimateName: `幻梦化蝶`,
+      skillUltimateDescription: `芙拉薇娅以自身为中心释放致幻领域，领域内的敌方单位造成致命伤害时，芙拉薇娅会化身为蝴蝶，短时间后重塑身体，继续战斗。领域外敌方无视重塑规则但仅在被攻击时可视芙拉薇娅。`,
+      subName: `遁入幻境`,
+      subDescription: `芙拉薇娅引动弦能，以自身为中心生成遮蔽视野的烟雾。芙拉薇娅可以在化蝶状态使用该技能，这样做将立即解除化蝶状态。`,
+    },
+    Yugiri: {
+      Name: '忧雾',
+      Type: '控场',
+      skillActiveName: `蚀甲毒雾`,
+      skillActiveDescription: `布置一个蜗牛装置，激活后可产生球形毒雾，临时腐蚀附近敌方角色的护甲。`,
+      skillPassiveName: `毒雾爆发`,
+      skillPassiveDescription: `使用主武器对敌方角色造成一定量的生命值伤害后，会引爆敌人体内的腐蚀性毒素，临时腐蚀附近敌方角色的护甲。`,
+      skillUltimateName: `凌毒侵蚀`,
+      skillUltimateDescription: `召唤大范围的毒雾向前方缓慢推进，腐蚀范围内敌方角色的护甲上限。`,
+      subName: `腐蚀溶液`,
+      subDescription: `忧雾向目标区域投掷毒液装置，毒液装置落地时会爆开并制造一片腐蚀区域，对区域内的敌人造成伤害与减速效果，弦化状态的敌人受到额外伤害。`,
+    },
+    Leona: {
+      Name: '蕾欧娜',
+      Type: '守护',
+      skillActiveName: `弦能掩墙`,
+      skillActiveDescription: `蕾欧娜可以在指定平地或斜坡生成两种角度的正方形建筑块。方块生成会消耗技能点数及弦能条。方块最多同时存在16个。`,
+      skillPassiveName: `劳逸结合`,
+      skillPassiveDescription: `蕾欧娜在弦化状态会持续恢复弦能，当弦能高于50%时，提高自身移动速度；低于50%时，逐渐恢复自身护甲。`,
+      skillUltimateName: `纯净坚城`,
+      skillUltimateDescription: `蕾欧娜充满弦能条，场上已存在方块和技能持续期间生成的方块永久变透明，透明方块将不再阻挡通路与友方子弹。`,
+      subName: `防弹护窗`,
+      subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
+    },
+    Ming: {
+      Name: '明',
+      Type: '决斗',
+      skillActiveName: `破甲电球`,
+      skillActiveDescription: `明发射一个电球，其达到最大距离、碰到敌方超弦体时会自动引爆，也可通过手动再次按下技能键后主动引爆。电球会破坏范围内所有敌方单位（包含召唤物）的护甲并造成减速。明进入电场将提升移动速度。`,
+      skillPassiveName: `吸能赋甲`,
+      skillPassiveDescription: `明使用枪械和主动技能对敌方护甲或护盾造成伤害时，自己的护甲将得到基于该伤害量的回复。绝招持续时间内，被动会回复临时护甲并增加回复量。`,
+      skillUltimateName: `强雷铸甲`,
+      skillUltimateDescription: `明获得临时护甲并使自己的射击附带可叠加的减速效果。明使用枪械和主动技能对敌人的护甲造成伤害时，可延长该技能持续时间并回复临时护甲。`,
+      subName: `爆闪电球`,
+      subDescription: `明可以发射一个闪光电球，再次按下技能键后或是到达最大飞行时间后引爆，并对周围所有敌人造成致盲效果，引爆前有一段延迟，延迟期间内闪光电球可以被摧毁。`,
+    },
+    Lawine: {
+      Name: '拉薇',
+      Type: '先锋',
+      skillActiveName: `寻影猎刃`,
+      skillActiveDescription: `拉薇投掷脉冲刀，制造一个磁力场，将一定范围内的敌方单位暴露给拉薇及其队友，脉冲刀每次扫描探测不到敌人时会立刻消失，最多扫描三次。`,
+      skillPassiveName: `曝影显踪`,
+      skillPassiveDescription: `拉薇主武器命中敌方单位时，会将其短暂透视给自己。`,
+      skillUltimateName: `遁影藏踪`,
+      skillUltimateDescription: `拉薇于自身正前方生成一片矩形磁场。进入磁场时，拉薇将进入隐身状态。隐身状态下的拉薇无法射击。`,
+      subName: `闪影猎刃`,
+      subDescription: `拉薇可以扔出一把闪光脉冲刀，脉冲刀插在障碍物上后引爆，并对周围所有敌人造成致盲效果，引爆前有一段延迟，延迟期间内飞刀可以被摧毁。`,
+    },
+    Meredith: {
+      Name: '梅瑞狄斯',
+      Type: '控场',
+      skillActiveName: `金沙热浪`,
+      skillActiveDescription: `梅瑞狄斯打出一颗弦能球体，于落点处创造一片黄沙领域，降低敌方角色移速和人机工效一段时间并暂时削减其生命值。`,
+      skillPassiveName: `时零沙环`,
+      skillPassiveDescription: `滞空状态下，当梅瑞狄斯进入技能瞄准、武器瞄准或者战术瞄准的状态时，自身的下落速度会被降低。`,
+      skillUltimateName: `流沙大葬`,
+      skillUltimateDescription: `梅瑞狄斯投掷出一个能制造巨大沙暴领域的金字塔。沙暴领域可以遮蔽视野，并暂时削减敌方角色生命值。`,
+      subName: `盲眼迷沙`,
+      subDescription: `梅瑞狄斯向目标方向发射弦能球体，于落点处创造一片完全遮蔽视野的环状黄沙领域。`,
+    },
+    Reiichi: {
+      Name: '令',
+      Type: '控场',
+      skillActiveName: `破晓帷幕`,
+      skillActiveDescription: `令使用自己的伞制造出一堵可以纵向释放或者横向释放的弦能光幕，光幕会遮蔽视野。`,
+      skillPassiveName: `黎明洞悉`,
+      skillPassiveDescription: `在保持开镜状态时，令每一段时间会扫描一遍前方敌人及其召唤物，使其透视，仅令可见。`,
+      skillUltimateName: `庇护圣屏`,
+      skillUltimateDescription: `立即刷新主动技能，在持续时间内增强光幕，使其能够格挡所有来自敌方角色的子弹。`,
+      subName: `圣屏突进`,
+      subDescription: `令释放一个可以向前推进的光幕，该光幕在准备释放阶段能够设置最终落点。`,
+    },
+    Kanami: {
+      Name: '香奈美',
+      Type: '先锋',
+      skillActiveName: `旋律回响`,
+      skillActiveDescription: `香奈美可以用枪射出声呐片，声呐片会释放出声波实时探查其前方180°一定范围内无建筑障碍物遮挡的敌人，被发现的敌人会暴露给香奈美及其队友。`,
+      skillPassiveName: `交响爆音`,
+      skillPassiveDescription: `香奈美的主武器发射子弹之后，会以子弹落点范围产生一个圆形音波区，处在音波区内的敌人信息会被暴露给香奈美自己。`,
+      skillUltimateName: `演出开始`,
+      skillUltimateDescription: `香奈美在战场内展开舞台，舞台展开后开始播放音乐，所有在舞台一定范围内的敌人都会被歌声吸引、减速、丢失准星的同时还会被晕眩，降低射速。`,
+      subName: `律动旋风`,
+      subDescription: `香奈美可以扔出一个迷你音响，制造一大片声风场区域，该风场会将所有进入风场内的角色吹起。在被吹起期间，敌方角色受到晕眩效果，友方角色获得移速提升效果，上述效果在离开风场区域后还会持续一段时间。`,
+    },
+    Eika: {
+      Name: '艾卡',
+      Type: '决斗',
+      skillActiveName: `炼狱牢笼`,
+      skillActiveDescription: `在面前生成一个球形火牢，敌人穿过牢壁受到火焰伤害，牢内没敌人时提前结束。艾卡在火牢内，主武器对内部敌人造成额外火焰伤害。消耗100热量所获增益：牢壁的伤害更高。`,
+      skillPassiveName: `日珥蓄火`,
+      skillPassiveDescription: `每次射击命中敌人会积攒热量，最多100值。满热时对弦化敌人造伤能力增强。满热下，其他技能可以消耗热量获得强化。`,
+      skillUltimateName: `烈焰风暴`,
+      skillUltimateDescription: `本回合内最多丢出3道烈焰风暴，吹飞敌人并造成火焰伤害。每发消耗100热量所获增益：风暴更大，伤害更高，且敌人高亮。`,
+      subName: `爆焰热弹`,
+      subDescription: `艾卡可以快速丢出一枚爆焰火球，火球落地时造成伤害，对弦化状态的敌人造成额外伤害。消耗100热量所获增益：提升伤害并附带减速效果。`,
+    },
+    Fragrans: {
+      Name: '珐格兰丝',
+      Type: '支援',
+      skillActiveName: `活力芬芳`,
+      skillActiveDescription: `珐格兰丝可以释放两种有限数量的香水。释放后会以自己为中心创造香氛区域，区域内己方会获得射速或移速提升，香氛效果会随着时间推移逐渐减弱，最终消失。`,
+      skillPassiveName: `复苏芳香`,
+      skillPassiveDescription: `珐格兰丝会散发淡淡的恢复香氛，附近的队友和自己都会缓慢恢复生命值。`,
+      skillUltimateName: `激昂芬芳`,
+      skillUltimateDescription: `珐格兰丝会以自己为中心制造强烈香氛区域，区域内友军会获得高额射速、移速提升和生命值恢复，该效果不会衰减且生命值恢复不会被伤害中断，释放期间珐格兰丝无法使用武器，但会获得大幅减伤。`,
+      subName: `香语众氛`,
+      subDescription: `珐格兰丝投掷出一瓶治疗香水，治疗香水触碰到障碍物时爆炸生效，制造一片回复生命区域，进入区域内的人会被赋予一段缓慢回复生命效果，即使离开区域也会持续一段时间。`,
+    },
+    Mara: {
+      Name: '玛拉',
+      Type: '决斗',
+      skillActiveName: `直击灵魂`,
+      skillActiveDescription: `向前施放鬼手，命中最近一名非倒地的敌方角色，使其灵魂出窍和减速。仅玛拉可通过武器攻击此灵魂球，对灵魂球造成伤害时，基于此一定比例给予敌人忽视护甲的血量伤害。敌人侧身或者飘飞时附着的灵魂球会缩小。`,
+      skillPassiveName: `摄魂侵魄`,
+      skillPassiveDescription: `玛拉使用武器对非满血敌方角色造成伤害时，会基于此伤害的一定比例恢复生命值以及对敌方角色造成额外忽视护甲的生命值伤害。此恢复效果同样适应于主动技能的灵魂球传导伤害。`,
+      skillUltimateName: `死神来了`,
+      skillUltimateDescription: `选择离自己最近的一名敌方角色施加死亡印记：该敌人会被沉默，及仅玛拉可视的暴露状态。在此期间当玛拉参与击倒或击杀此角色，此印记会传导给一定范围内离玛拉最近的非倒地敌人，并重新计时。此效果会持续到玛拉死亡或者时间结束。`,
+      subName: `亡灵漫步`,
+      subDescription: `开启后，玛拉弦化时会进入特殊隐身状态，当敌人逐渐靠近时玛拉才会显形；且弦化移速增加；在终极技能触发时，显形的最远距离会进一步缩小。`,
+    },
+    Celestia: {
+      Name: '星绘',
+      Type: '支援',
+      skillActiveName: `守护星芒`,
+      skillActiveDescription: `星绘选择一个友方角色，投掷流星弦能，赋予其临时护甲。之后流星弦能将返回星绘身边，赋予星绘临时护甲。`,
+      skillPassiveName: `星弦甲生`,
+      skillPassiveDescription: `星绘周围有友方角色时，可缓慢恢复该角色与自身的护甲值。`,
+      skillUltimateName: `星空之门`,
+      skillUltimateDescription: `星绘选择一个友方角色，为该队友和自身提供临时护甲值，并开始蓄能。蓄能完毕后，星绘将传送到该角色身边，蓄能期间按下大招键可取消传送（不取消护甲增益）。`,
+      subName: `塑甲星芒`,
+      subDescription: `星绘向目标区域掷出星芒，星芒触碰到障碍物时爆炸生效，制造一片回复护甲区域，进入区域内的人会被赋予一段缓慢回复护甲效果，即使离开区域也会持续一段时间。`,
+    },
+    Audrey: {
+      Name: '奥黛丽',
+      Type: '守护',
+      skillActiveName: `重火倾泄`,
+      skillActiveDescription: `进入架设状态，大幅提升射速，无后坐力，连续射击不需更换弹匣。若奥黛丽的连续射击时间过长，便会进入枪口过热状态无法射击。`,
+      skillPassiveName: `皇家盾牌`,
+      skillPassiveDescription: `奥黛丽进入架枪模式或进入开镜模式时，召唤护盾守护自身正面，且架枪模式下会获得额外护盾最大值。`,
+      skillUltimateName: `狂轰滥炸`,
+      skillUltimateDescription: `奥黛丽架设一把榴弹发射器，可发射六枚榴弹炮。榴弹炮爆炸后会分裂成弹跳炸弹，弹跳炸弹爆炸时将于地面生成火海。`,
+      subName: `警报雷达`,
+      subDescription: `奥黛丽丢出一个警报雷达，雷达落地后展开并对周围持续进行扫描，扫描到敌人时提示敌人的数量并对敌人施加短暂透视效果。`,
+    },
+    Maddelena: {
+      Name: '玛德蕾娜',
+      Type: '控场',
+      skillActiveName: `颜料束缚`,
+      skillActiveDescription: `玛德蕾娜发射一滩颜料，经过这滩颜料的敌人将被减速、弦化禁止并暴露脚印。`,
+      skillPassiveName: `颜料脚印`,
+      skillPassiveDescription: `玛德蕾娜使用主武器命中敌方角色时，可使敌方角色减速并暴露脚印。`,
+      skillUltimateName: `颜料泡泡`,
+      skillUltimateDescription: `玛德蕾娜发射巨大泡泡，泡泡内的敌人将被禁止弦化且暴露脚印。泡泡爆炸后将对爆炸范围内的敌人施加额外的减速和易伤效果。`,
+      subName: `颜料泡涌`,
+      subDescription: `玛德蕾娜向前方发射颜料泡，再次按下技能键后颜料泡会停留在原地，颜料泡会对碰到的敌人造成减速和弦化禁止效果。`,
+    },
+    Fuchsia: {
+      Name: '绯莎',
+      Type: '决斗',
+      skillActiveName: `残息追踪`,
+      skillActiveDescription: `对周围敌人感知，满血敌人被短暂透视，生命值不满则被持续透视，上述效果仅自己可视。感应到敌人将增加绯莎的移动速度。`,
+      skillPassiveName: `以战养战`,
+      skillPassiveDescription: `绯莎参与击破时，死亡的敌人将原地掉落能量晶体。绯莎可以靠近并吸收能量晶体，回复自身生命值。绯莎第一次吸取能量晶体时可增加自身生命值上限。`,
+      skillUltimateName: `浴血狂戮`,
+      skillUltimateDescription: `绯莎大幅度提升自身的射速和人机工效，并使得主动技能可令视野内敌人高亮。吸收能量晶体将延长该效果持续时间。`,
+      subName: `猩红猛冲`,
+      subDescription: `绯莎消耗当前一定百分比生命值，获得移速提升效果，持续一段时间。`,
+    },
+    BaiMo: {
+      Name: '白墨',
+      Type: '决斗',
+      skillActiveName: `炫空斗舞`,
+      skillActiveDescription: `白墨进入弦化状态，向前翻转跳跃贴近敌人，并为主武器自动补充子弹。白墨参与击破将刷新冷却。`,
+      skillPassiveName: `嘻哈嘣彩`,
+      skillPassiveDescription: `白墨的主武器单次射击命中敌人造成至少50点伤害后，使其弦化禁止。`,
+      skillUltimateName: `重返街头`,
+      skillUltimateDescription: `白墨原地放置一个重生信标，死亡或倒地时可以立即在信标处重生。白墨可以选择主动返回信标，并回复全部生命值。`,
+      subName: `爆炸涂鸦`,
+      subDescription: `白墨快速向前投掷出颜料罐，颜料罐爆炸时对周围敌人造成禁止弦化效果。`,
+    },
+    Galatea: {
+      Name: '加拉蒂亚',
+      Type: '先锋',
+      skillActiveName: `飞牌瞬闪`,
+      skillActiveDescription: `加拉蒂亚释放出一张卡牌以弧线飞出，卡牌碰到地面、墙面时会生成分身，按下交互键可以传送到分身位置。`,
+      skillPassiveName: `欺诈牌影`,
+      skillPassiveDescription: `当加拉蒂亚脱离墙面时，会在贴墙位置留下一个分身，每次下墙都会重新生成分身，当分身受伤时该被动进入冷却。加拉蒂亚的每一个分身在生成时都可以短暂探测周围无建筑障碍物遮挡的敌人给加拉蒂亚及全体友方，攻击分身的敌人也会被暂时暴露。`,
+      skillUltimateName: `牌影戏法`,
+      skillUltimateDescription: `加拉蒂亚朝前方随意投出大量卡牌，每一个卡牌都可以生成分身并让加拉蒂亚传送。`,
+      subName: `致盲牌影`,
+      subDescription: `加拉蒂亚可以释放一个特殊的卡片分身，加拉蒂亚无法传送到该分身的位置，该分身被敌人摧毁时，会对周围所有敌人造成闪光效果。`,
+    },
+  },
+  characterTypes: {
+    Sentinel: '守护',
+    Support: '支援',
+    Controller: '控场',
+    Duellist: '决斗',
+    Initiator: '先锋',
+  },
+  grenades: {
+    Flashbang: '闪光弹',
+    FragGrenade: '手雷',
+    HealingGrenade: '治疗雷',
+    Interceptor: '拦截者',
+    SlowGrenade: '减速雷',
+    SmokeBomb: '烟雾弹',
+    Alarm: '警报器',
+    WindstormGrenade: '风场雷',
+    SnowBall: '雪球',
+  },
+  others: {
+    Bomb: 'Bomb',
+    BombA: 'Bomb A',
+    BombB: 'Bomb B',
+    BombC: 'Bomb C',
+    Focus: 'Focus',
+    Warning: 'Warning',
+    Flag: 'Flag',
+    Danger: 'Danger',
+  },
+  markbox: {
+    mark: '画笔',
+    straightline: '直线',
+    arrowline: '箭头',
+    color: '颜色',
+    undo: '撤销',
+    clear: '清空',
+    clearwarning: {
+      title: '确认清除所有笔迹？',
+      content: '此操作不可撤销',
+      ok: '确认',
+      cancel: '取消',
+      success: '已清除所有笔迹',
+      failure: '清除笔迹失败',
+    },
+  },
+};

--- a/src/data/liveShare.ts
+++ b/src/data/liveShare.ts
@@ -1,275 +1,359 @@
 //@ts-ignore
-import { Peer } from "peerjs/dist/bundler.mjs";
+import { Peer } from 'peerjs/dist/bundler.mjs';
 import { Toast } from '@douyinfe/semi-ui';
 
 import { getCurrentAppState, loadCurrentAppState } from './stateManagement';
 
 export enum ConnectionState {
-  "DISCONNECTED" = "DISCONNECTED",
-  "CONNECTING" = "CONNECTING",
-  "CONNECTED" = "CONNECTED",
-  "DISCONNECTING" = "DISCONNECTING",
+  'DISCONNECTED' = 'DISCONNECTED',
+  'CONNECTING' = 'CONNECTING',
+  'CONNECTED' = 'CONNECTED',
+  'DISCONNECTING' = 'DISCONNECTING',
 }
 
-let lastAppState: any = null
-let drawInteraction = true
-let drawInteractionTO: any = null
+let lastAppState: any = null;
+let drawInteraction = true;
+let drawInteractionTO: any = null;
 export class Lobby {
-  connectionState: ConnectionState = ConnectionState.DISCONNECTED
-  peer: any
-  conn: any
-  connections: any[] = []
-  id?: string
-  peerIds: string[] = ['', '', '', '', '', '', '', '', '', '']
-  args: any
+  connectionState: ConnectionState = ConnectionState.DISCONNECTED;
+  peer: any;
+  conn: any;
+  connections: any[] = [];
+  id?: string;
+  peerIds: string[] = ['', '', '', '', '', '', '', '', '', ''];
+  args: any;
   constructor(args: any) {
-    this.connections = []
-    this.args = args
+    this.connections = [];
+    this.args = args;
   }
   listen() {
-    Toast.info('Processing')
-    const s = this
-    const { presentMap, setPresentMap, setPresentMapURL, mapPrepareMode, setMapPrepareMode, drawCanvasEditor } = s.args
-    if (s.peer) return
-    s.peer = new Peer()
-    s.connectionState = ConnectionState.CONNECTING
-    s.peer.on("open", (id: string) => {
-      s.id = id
-      s.connectionState = ConnectionState.CONNECTED
+    Toast.info('Processing');
+    const s = this;
+    const {
+      presentMap,
+      setPresentMap,
+      setPresentMapURL,
+      mapPrepareMode,
+      setMapPrepareMode,
+      drawCanvasEditor,
+    } = s.args;
+    if (s.peer) return;
+    s.peer = new Peer();
+    s.connectionState = ConnectionState.CONNECTING;
+    s.peer.on('open', (id: string) => {
+      s.id = id;
+      s.connectionState = ConnectionState.CONNECTED;
       if (location.hash == '') {
-        location.hash = id
-        Toast.success('Sharing started')
+        location.hash = id;
+        Toast.success('Sharing started');
       } else {
-        s.connect({ id: location.hash.replace('#', '') })
+        s.connect({ id: location.hash.replace('#', '') });
         setTimeout(() => {
-          if(location.hash) {
-            let hash = location.hash.replace('#', '')
-            let found = s.id === hash
+          if (location.hash) {
+            let hash = location.hash.replace('#', '');
+            let found = s.id === hash;
             for (let i = 0; i < s.connections.length; i++) {
               if (s.connections[i].peer === hash) {
-                found = true
-                break
+                found = true;
+                break;
               }
             }
-            if(!found) {
-              location.hash = s.id as string
+            if (!found) {
+              location.hash = s.id as string;
             }
           }
         }, 1000);
       }
-      s.heartbeat()
-      rebindShare()
-    })
+      s.heartbeat();
+      rebindShare();
+    });
 
-    s.peer.on("connection", (connection: any) => {
-      s.connections.push(connection)
-      let disconnectConnectionTO = setTimeout(() => { s.disconnectConnection(connection)}, 10000)
-      connection.on("data", (data: any) => {
-        clearTimeout(disconnectConnectionTO)
-        disconnectConnectionTO = setTimeout(() => { s.disconnectConnection(connection)}, 10000)
+    s.peer.on('connection', (connection: any) => {
+      s.connections.push(connection);
+      let disconnectConnectionTO = setTimeout(() => {
+        s.disconnectConnection(connection);
+      }, 10000);
+      connection.on('data', (data: any) => {
+        clearTimeout(disconnectConnectionTO);
+        disconnectConnectionTO = setTimeout(() => {
+          s.disconnectConnection(connection);
+        }, 10000);
         if (data.type === 'joinRequest') {
-          if (s.peerIds.indexOf((s.id as string)) === -1 && s.peerIds.indexOf('') !== -1) {
-            s.peerIds[s.peerIds.indexOf('')] = s.id as string
+          if (
+            s.peerIds.indexOf(s.id as string) === -1 &&
+            s.peerIds.indexOf('') !== -1
+          ) {
+            s.peerIds[s.peerIds.indexOf('')] = s.id as string;
           }
-          const joinPeerIdIndex = s.peerIds.indexOf('')
+          const joinPeerIdIndex = s.peerIds.indexOf('');
           if (joinPeerIdIndex !== -1) {
-            s.peerIds[joinPeerIdIndex] = connection.peer
-            const currentAppState = getCurrentAppState({ presentMap, mapPrepareMode, drawCanvasEditor })
-            const sendJoinResponse = { type: "joinResponse", peerIds: s.peerIds, state: currentAppState }
-            connection.send(sendJoinResponse)
+            s.peerIds[joinPeerIdIndex] = connection.peer;
+            const currentAppState = getCurrentAppState({
+              presentMap,
+              mapPrepareMode,
+              drawCanvasEditor,
+            });
+            const sendJoinResponse = {
+              type: 'joinResponse',
+              peerIds: s.peerIds,
+              state: currentAppState,
+            };
+            connection.send(sendJoinResponse);
             for (let i = 0; i < s.peerIds.length; i++) {
               const peerId = s.peerIds[i];
               if (peerId != s.id && peerId != connection.peer) {
-                const peerIdConnection = s.connections.find(c => c.peer === peerId)
-                peerIdConnection?.send(sendJoinResponse)
+                const peerIdConnection = s.connections.find(
+                  (c) => c.peer === peerId,
+                );
+                peerIdConnection?.send(sendJoinResponse);
               }
             }
           }
-          const peerIdConnection = s.connections.find(c => s.peerIds.indexOf(c.peer) !== -1)
+          const peerIdConnection = s.connections.find(
+            (c) => s.peerIds.indexOf(c.peer) !== -1,
+          );
           if (!peerIdConnection) {
-            connection.close()
-            let i = s.connections.length
+            connection.close();
+            let i = s.connections.length;
             while (i--) {
               if (s.connections[i].peer === connection.peer) {
-                s.connections.splice(i, 1)
+                s.connections.splice(i, 1);
               }
             }
           }
         } else if (data.type === 'state') {
-          lastAppState = data.state
-          drawInteraction = false
-          clearTimeout(drawInteractionTO)
-          drawInteractionTO =setTimeout(() => { drawInteraction = true }, 2000)
-          loadCurrentAppState({ json: data.state, setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor })
+          lastAppState = data.state;
+          drawInteraction = false;
+          clearTimeout(drawInteractionTO);
+          drawInteractionTO = setTimeout(() => {
+            drawInteraction = true;
+          }, 2000);
+          loadCurrentAppState({
+            json: data.state,
+            setPresentMap,
+            setPresentMapURL,
+            setMapPrepareMode,
+            drawCanvasEditor,
+          });
         }
-      })
-    })
+      });
+    });
   }
   reconnect() {
-    const s = this
-    s.peer.reconnect()
+    const s = this;
+    s.peer.reconnect();
   }
   heartbeat() {
-    let s = this
-    if (s.connectionState !== ConnectionState.DISCONNECTED || !s.connectionState) {
-      setTimeout(() => { s.heartbeat() }, 5000)
+    let s = this;
+    if (
+      s.connectionState !== ConnectionState.DISCONNECTED ||
+      !s.connectionState
+    ) {
+      setTimeout(() => {
+        s.heartbeat();
+      }, 5000);
     }
     for (let i = 0; i < s.connections?.length; i++) {
-      const c = s.connections[i]
-      if(c.open) {
-        c.send({type:'heartbeat' })
+      const c = s.connections[i];
+      if (c.open) {
+        c.send({ type: 'heartbeat' });
       }
     }
   }
   connect({ id }: { id: string }) {
-    const s = this
-    const { setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor } = s.args
-    const connection = s.peer.connect(id, { reliable: true, ebug: 3 })
-    connection.on("open", () => {
-      s.connections.push(connection)
-      let disconnectConnectionTO = setTimeout(() => { s.disconnectConnection(connection)}, 10000)
-      connection.send({ type: 'joinRequest' })
+    const s = this;
+    const {
+      setPresentMap,
+      setPresentMapURL,
+      setMapPrepareMode,
+      drawCanvasEditor,
+    } = s.args;
+    const connection = s.peer.connect(id, { reliable: true, ebug: 3 });
+    connection.on('open', () => {
+      s.connections.push(connection);
+      let disconnectConnectionTO = setTimeout(() => {
+        s.disconnectConnection(connection);
+      }, 10000);
+      connection.send({ type: 'joinRequest' });
       connection.on('data', function (data: any) {
-        clearTimeout(disconnectConnectionTO)
-        disconnectConnectionTO = setTimeout(() => { s.disconnectConnection(connection)}, 10000)
+        clearTimeout(disconnectConnectionTO);
+        disconnectConnectionTO = setTimeout(() => {
+          s.disconnectConnection(connection);
+        }, 10000);
         if (data.type === 'joinResponse') {
-          s.peerIds = data.peerIds
+          s.peerIds = data.peerIds;
           for (let i = 0; i < s.peerIds.length; i++) {
-            const peerId = s.peerIds[i]
+            const peerId = s.peerIds[i];
             if (peerId != s.id) {
-              const peerIdConnection = s.connections.find(c => c.peer === peerId)
+              const peerIdConnection = s.connections.find(
+                (c) => c.peer === peerId,
+              );
               if (!peerIdConnection) {
-                s.connect({ id: peerId })
+                s.connect({ id: peerId });
               }
             }
           }
-          lastAppState = data.state
-          drawInteraction = false
-          clearTimeout(drawInteractionTO)
-          drawInteractionTO =setTimeout(() => { drawInteraction = true }, 2000)
-          loadCurrentAppState({ json: data.state, setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor })
+          lastAppState = data.state;
+          drawInteraction = false;
+          clearTimeout(drawInteractionTO);
+          drawInteractionTO = setTimeout(() => {
+            drawInteraction = true;
+          }, 2000);
+          loadCurrentAppState({
+            json: data.state,
+            setPresentMap,
+            setPresentMapURL,
+            setMapPrepareMode,
+            drawCanvasEditor,
+          });
         } else if (data.type === 'state') {
-          lastAppState = data.state
-          drawInteraction = false
-          clearTimeout(drawInteractionTO)
-          drawInteractionTO =setTimeout(() => { drawInteraction = true }, 2000)
-          loadCurrentAppState({ json: data.state, setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor })
+          lastAppState = data.state;
+          drawInteraction = false;
+          clearTimeout(drawInteractionTO);
+          drawInteractionTO = setTimeout(() => {
+            drawInteraction = true;
+          }, 2000);
+          loadCurrentAppState({
+            json: data.state,
+            setPresentMap,
+            setPresentMapURL,
+            setMapPrepareMode,
+            drawCanvasEditor,
+          });
         }
-      })
-    })
-    connection.on("close", () => {
-      console.log('connect close', connection.peer)
-    })
-    connection.on("error", (err: any) => {
-      console.log('connect error', connection.peer, err)
-      Toast.error('Connect error!')
-    })
-    connection.on("disconnected", (err: any) => {
-      console.log('connect disconnected', connection.peer, err)
-      Toast.error('Connect disconnected!')
-    })
+      });
+    });
+    connection.on('close', () => {
+      console.log('connect close', connection.peer);
+    });
+    connection.on('error', (err: any) => {
+      console.log('connect error', connection.peer, err);
+      Toast.error('Connect error!');
+    });
+    connection.on('disconnected', (err: any) => {
+      console.log('connect disconnected', connection.peer, err);
+      Toast.error('Connect disconnected!');
+    });
   }
   disconnectConnection(connection: any) {
-    const s = this
-    let i = s.connections.length
+    const s = this;
+    let i = s.connections.length;
     while (i--) {
       if (s.connections[i].peer === connection.peer) {
-        s.connections.splice(i, 1)
+        s.connections.splice(i, 1);
       }
     }
-    const peerIdIndex = s.peerIds.indexOf(connection.peer)
+    const peerIdIndex = s.peerIds.indexOf(connection.peer);
     if (peerIdIndex !== -1) {
-      s.peerIds[peerIdIndex] = ''
+      s.peerIds[peerIdIndex] = '';
     }
-    if(location.hash) {
-      let hash = location.hash.replace('#', '')
-      let found = s.id === hash
+    if (location.hash) {
+      let hash = location.hash.replace('#', '');
+      let found = s.id === hash;
       for (let i = 0; i < s.connections.length; i++) {
         if (s.connections[i].peer === hash) {
-          found = true
-          break
+          found = true;
+          break;
         }
       }
-      if(!found) {
-        location.hash = s.id as string
+      if (!found) {
+        location.hash = s.id as string;
       }
     }
   }
   destroy() {
-    location.hash = ''
-    this.peer && this.peer.disconnect()
-    this.connectionState = ConnectionState.DISCONNECTED
-    this.connections = []
-    this.peerIds = ['', '', '', '', '', '', '', '', '', '']
-    this.id = this.peer = this.conn = undefined
-    Toast.success('Sharing closed')
+    location.hash = '';
+    this.peer && this.peer.disconnect();
+    this.connectionState = ConnectionState.DISCONNECTED;
+    this.connections = [];
+    this.peerIds = ['', '', '', '', '', '', '', '', '', ''];
+    this.id = this.peer = this.conn = undefined;
+    Toast.success('Sharing closed');
   }
 }
 
 export const initShare = (args: any) => {
   if (!lobby) {
-    lobby = new Lobby(args)
+    lobby = new Lobby(args);
   }
-}
+};
 
 export const cleanUpShare = () => {
   if (lobby) {
-    lobby.destroy()
+    lobby.destroy();
   }
-}
+};
 
-let drawTO: any = null
+let drawTO: any = null;
 export const rebindShare = () => {
   if (lobby && lobby.connectionState === ConnectionState.CONNECTED) {
-    const { drawCanvasEditor } = lobby.args
+    const { drawCanvasEditor } = lobby.args;
     const delayUpdateLiveMap = () => {
-      clearTimeout(drawTO)
-      drawTO = setTimeout(updateLiveMap, 1000)
-    }
+      clearTimeout(drawTO);
+      drawTO = setTimeout(updateLiveMap, 1000);
+    };
     // const drawEvents = ['*']
-    const drawEvents = ['shape:create', 'shape:delete', 'selection:dragend', 'board:change-active-drawing', 'history:undo', 'history:redo', 'selection:transformend']
-    drawCanvasEditor.off(drawEvents, delayUpdateLiveMap)
-    drawCanvasEditor.on(drawEvents, delayUpdateLiveMap)
+    const drawEvents = [
+      'shape:create',
+      'shape:delete',
+      'selection:dragend',
+      'board:change-active-drawing',
+      'history:undo',
+      'history:redo',
+      'selection:transformend',
+    ];
+    drawCanvasEditor.off(drawEvents, delayUpdateLiveMap);
+    drawCanvasEditor.on(drawEvents, delayUpdateLiveMap);
   }
-}
+};
 
 export const updateLiveMap = () => {
   if (lobby && lobby.connectionState === ConnectionState.CONNECTED) {
-    const { presentMap, mapPrepareMode, drawCanvasEditor } = lobby.args
-    const currentAppState = getCurrentAppState({ presentMap, mapPrepareMode, drawCanvasEditor })
-    if (drawInteraction && JSON.stringify(lastAppState) != JSON.stringify(currentAppState)) {
+    const { presentMap, mapPrepareMode, drawCanvasEditor } = lobby.args;
+    const currentAppState = getCurrentAppState({
+      presentMap,
+      mapPrepareMode,
+      drawCanvasEditor,
+    });
+    if (
+      drawInteraction &&
+      JSON.stringify(lastAppState) != JSON.stringify(currentAppState)
+    ) {
       for (let i = 0; i < lobby.connections.length; i++) {
-        const c = lobby.connections[i]
+        const c = lobby.connections[i];
         if (lobby.id != c.peer && c.open) {
-          c.send({ type: 'state', state: currentAppState })
+          c.send({ type: 'state', state: currentAppState });
         }
       }
-      lastAppState = currentAppState
+      lastAppState = currentAppState;
     }
   }
-}
+};
 
-let lobby: Lobby
-let shareTO: any
+let lobby: Lobby;
+let shareTO: any;
 export const share = ({ ui }: any = {}) => {
-  clearTimeout(shareTO)
+  clearTimeout(shareTO);
   shareTO = setTimeout(() => {
-    if (((!location.hash && ui) || (!ui && location.hash)) && lobby.connectionState === ConnectionState.DISCONNECTED) {
+    if (
+      ((!location.hash && ui) || (!ui && location.hash)) &&
+      lobby.connectionState === ConnectionState.DISCONNECTED
+    ) {
       if (lobby && !lobby.peer) {
-        lobby.listen()
+        lobby.listen();
       } else if (lobby && !lobby.peer) {
-        lobby.reconnect()
+        lobby.reconnect();
       }
     } else if (location.hash && ui) {
-      lobby.destroy()
+      lobby.destroy();
     }
-  }, 1000)
-}
+  }, 1000);
+};
 
 export const updateLobbyRefs = ({ presentMap, mapPrepareMode }: any) => {
-  if(lobby) {
-    lobby.args.presentMap = presentMap
-    lobby.args.mapPrepareMode = mapPrepareMode
+  if (lobby) {
+    lobby.args.presentMap = presentMap;
+    lobby.args.mapPrepareMode = mapPrepareMode;
   }
-  return lobby
-}
+  return lobby;
+};

--- a/src/data/maplist.ts
+++ b/src/data/maplist.ts
@@ -1,13 +1,13 @@
 // The value of each key represents the corresponding key in the language file
 export enum MapName {
-  WindyTown = "WindyTown",
-  SpaceLab = "SpaceLab",
-  Khesmet = "Khesmet",
-  EulerPort = "EulerPort",
-  CauchyDistrict = "CauchyDistrict",
-  Area88 = "Area88",
-  Base404 = "Base404",
-  Ocarnus = "Ocarnus"
+  WindyTown = 'WindyTown',
+  SpaceLab = 'SpaceLab',
+  Khesmet = 'Khesmet',
+  EulerPort = 'EulerPort',
+  CauchyDistrict = 'CauchyDistrict',
+  Area88 = 'Area88',
+  Base404 = 'Base404',
+  Ocarnus = 'Ocarnus',
 }
 
 interface MapList {
@@ -19,36 +19,42 @@ interface MapList {
 export const mapList: MapList[] = [
   {
     map: MapName.WindyTown,
-    imgPrepareLink: "https://s2.loli.net/2024/09/24/Shk6rXTwvAlDGMC.png",
-    imgBlankLink: "https://s2.loli.net/2024/09/24/85uxWct3DeRByTO.png"
-  }, {
+    imgPrepareLink: 'https://s2.loli.net/2024/09/24/Shk6rXTwvAlDGMC.png',
+    imgBlankLink: 'https://s2.loli.net/2024/09/24/85uxWct3DeRByTO.png',
+  },
+  {
     map: MapName.SpaceLab,
-    imgPrepareLink: "https://s2.loli.net/2024/09/24/QI6hnMtsJpSCKgE.png",
-    imgBlankLink: "https://s2.loli.net/2024/09/24/KxUYEBqdlyZ92rC.png"
-  }, {
+    imgPrepareLink: 'https://s2.loli.net/2024/09/24/QI6hnMtsJpSCKgE.png',
+    imgBlankLink: 'https://s2.loli.net/2024/09/24/KxUYEBqdlyZ92rC.png',
+  },
+  {
     map: MapName.Khesmet,
-    imgPrepareLink: "https://s2.loli.net/2024/09/24/QnNZHhT4wDbFxIO.png",
-    imgBlankLink: "https://s2.loli.net/2024/09/24/jroCB9iqR1l5LDp.png"
-  }, {
+    imgPrepareLink: 'https://s2.loli.net/2024/09/24/QnNZHhT4wDbFxIO.png',
+    imgBlankLink: 'https://s2.loli.net/2024/09/24/jroCB9iqR1l5LDp.png',
+  },
+  {
     map: MapName.EulerPort,
-    imgPrepareLink: "https://s2.loli.net/2024/09/24/Md2Pa1HKtJyk7oO.png",
-    imgBlankLink: "https://s2.loli.net/2024/09/24/NGWk2HXwSvmdgOY.png"
-  }, {
+    imgPrepareLink: 'https://s2.loli.net/2024/09/24/Md2Pa1HKtJyk7oO.png',
+    imgBlankLink: 'https://s2.loli.net/2024/09/24/NGWk2HXwSvmdgOY.png',
+  },
+  {
     map: MapName.CauchyDistrict,
-    imgPrepareLink: "https://s2.loli.net/2024/09/24/Uw3ftVPQOLu5MCj.png",
-    imgBlankLink: "https://s2.loli.net/2024/09/24/cLDQtdwAJyr2k7T.png"
-  }, {
+    imgPrepareLink: 'https://s2.loli.net/2024/09/24/Uw3ftVPQOLu5MCj.png',
+    imgBlankLink: 'https://s2.loli.net/2024/09/24/cLDQtdwAJyr2k7T.png',
+  },
+  {
     map: MapName.Area88,
-    imgPrepareLink: "https://s2.loli.net/2024/09/24/wouqxsUy1JaP8l6.png",
-    imgBlankLink: "https://s2.loli.net/2024/09/24/YBUsSC78oOrx16W.png"
-  }, {
+    imgPrepareLink: 'https://s2.loli.net/2024/09/24/wouqxsUy1JaP8l6.png',
+    imgBlankLink: 'https://s2.loli.net/2024/09/24/YBUsSC78oOrx16W.png',
+  },
+  {
     map: MapName.Base404,
-    imgPrepareLink: "https://s2.loli.net/2024/09/24/XfMi4qcV5zmTy78.png",
-    imgBlankLink: "https://s2.loli.net/2024/09/24/pjGMHJClRsXEoAf.png"
-  }, {
+    imgPrepareLink: 'https://s2.loli.net/2024/09/24/XfMi4qcV5zmTy78.png',
+    imgBlankLink: 'https://s2.loli.net/2024/09/24/pjGMHJClRsXEoAf.png',
+  },
+  {
     map: MapName.Ocarnus,
-    imgPrepareLink: "https://cdn.sa.net/2025/04/22/HAisD5nj9Plz4dV.png",
-    imgBlankLink: "https://cdn.sa.net/2025/04/22/pzYjVHbdiL3qn7c.webp"
-  }
+    imgPrepareLink: 'https://cdn.sa.net/2025/04/22/HAisD5nj9Plz4dV.png',
+    imgBlankLink: 'https://cdn.sa.net/2025/04/22/pzYjVHbdiL3qn7c.webp',
+  },
 ];
-

--- a/src/data/stateManagement.ts
+++ b/src/data/stateManagement.ts
@@ -1,51 +1,92 @@
 import { MapName, mapList } from '../data/maplist';
 
-export const getCurrentAppState = ({ presentMap, mapPrepareMode, drawCanvasEditor }: any) => {
-    return ({ v: '1.0.0', map: presentMap, mapHighlight: mapPrepareMode, editor: drawCanvasEditor?.export.toJson() } as any)
-}
+export const getCurrentAppState = ({
+  presentMap,
+  mapPrepareMode,
+  drawCanvasEditor,
+}: any) => {
+  return {
+    v: '1.0.0',
+    map: presentMap,
+    mapHighlight: mapPrepareMode,
+    editor: drawCanvasEditor?.export.toJson(),
+  } as any;
+};
 
-export const loadCurrentAppState = ({ json, setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor }: any) => {
-    if (json.map in MapName) {
-        setPresentMap(json.map)
-        for (const mapinfo of mapList) {
-            if (mapinfo.map === json.map) {
-                drawCanvasEditor?.reset()
-                setPresentMapURL({ imgPrepareLink: mapinfo.imgPrepareLink, imgBlankLink: mapinfo.imgBlankLink })
-            }
-        }
+export const loadCurrentAppState = ({
+  json,
+  setPresentMap,
+  setPresentMapURL,
+  setMapPrepareMode,
+  drawCanvasEditor,
+}: any) => {
+  if (json.map in MapName) {
+    setPresentMap(json.map);
+    for (const mapinfo of mapList) {
+      if (mapinfo.map === json.map) {
+        drawCanvasEditor?.reset();
+        setPresentMapURL({
+          imgPrepareLink: mapinfo.imgPrepareLink,
+          imgBlankLink: mapinfo.imgBlankLink,
+        });
+      }
     }
-    if(json.mapHighlight != null) {
-        setMapPrepareMode(json.mapHighlight)
-    }
-    if (json.editor) {
-        drawCanvasEditor?.import.json(json.editor)
-    }
-}
+  }
+  if (json.mapHighlight != null) {
+    setMapPrepareMode(json.mapHighlight);
+  }
+  if (json.editor) {
+    drawCanvasEditor?.import.json(json.editor);
+  }
+};
 
 export const save = ({ presentMap, mapPrepareMode, drawCanvasEditor }: any) => {
-    const a = document.createElement("a")
-    const file = new Blob(
-        [JSON.stringify(getCurrentAppState({ presentMap, mapPrepareMode, drawCanvasEditor }))],
-        { type: 'text/plain' }
-    )
-    const Presentdate = new Date()
-    const presenttime = Presentdate.getFullYear().toString() + (Presentdate.getMonth() + 1 < 10 ? "0" : "") + (Presentdate.getMonth() + 1).toString() + (Presentdate.getDate() < 10 ? "0" : "") + Presentdate.getDate().toString() + Presentdate.getHours().toString() + Presentdate.getMinutes().toString() + Presentdate.getSeconds().toString()
-    a.href = URL.createObjectURL(file)
-    a.download = `SMA_${presentMap.replace(/ /g, '_')}_${presenttime}.json`
-    a.click()
-}
+  const a = document.createElement('a');
+  const file = new Blob(
+    [
+      JSON.stringify(
+        getCurrentAppState({ presentMap, mapPrepareMode, drawCanvasEditor }),
+      ),
+    ],
+    { type: 'text/plain' },
+  );
+  const Presentdate = new Date();
+  const presenttime =
+    Presentdate.getFullYear().toString() +
+    (Presentdate.getMonth() + 1 < 10 ? '0' : '') +
+    (Presentdate.getMonth() + 1).toString() +
+    (Presentdate.getDate() < 10 ? '0' : '') +
+    Presentdate.getDate().toString() +
+    Presentdate.getHours().toString() +
+    Presentdate.getMinutes().toString() +
+    Presentdate.getSeconds().toString();
+  a.href = URL.createObjectURL(file);
+  a.download = `SMA_${presentMap.replace(/ /g, '_')}_${presenttime}.json`;
+  a.click();
+};
 
-export const load = ({ setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor }: any) => {
-    const input = document.createElement("input")
-    input.type = "file"
-    input.accept = ".json"
-    input.addEventListener("change", function (e) {
-        const file = (e.target as any).files[0]
-        const reader = new FileReader()
-        reader.onload = function (e) {
-            loadCurrentAppState({ setPresentMap, setPresentMapURL, setMapPrepareMode, drawCanvasEditor, json: JSON.parse(e.target!.result as string) })
-        }
-        reader.readAsText(file)
-    });
-    input.click()
-}
+export const load = ({
+  setPresentMap,
+  setPresentMapURL,
+  setMapPrepareMode,
+  drawCanvasEditor,
+}: any) => {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json';
+  input.addEventListener('change', function (e) {
+    const file = (e.target as any).files[0];
+    const reader = new FileReader();
+    reader.onload = function (e) {
+      loadCurrentAppState({
+        setPresentMap,
+        setPresentMapURL,
+        setMapPrepareMode,
+        drawCanvasEditor,
+        json: JSON.parse(e.target!.result as string),
+      });
+    };
+    reader.readAsText(file);
+  });
+  input.click();
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -1,207 +1,212 @@
-import { factions, PUS, TheScissors, Urbino } from "../data/characters/factions"
-import { grenades, others } from "../data/grenades"
-import { MapName } from "../data/maplist"
+import {
+  factions,
+  PUS,
+  TheScissors,
+  Urbino,
+} from '../data/characters/factions';
+import { grenades, others } from '../data/grenades';
+import { MapName } from '../data/maplist';
 
 export enum Languages {
-	en_US = 'English',
-	zh_CN = '简体中文',
-	ja_JP = '日本語'
+  en_US = 'English',
+  zh_CN = '简体中文',
+  ja_JP = '日本語',
 }
 
 interface CharacterTypes {
-	Sentinel: string,
-	Support: string,
-	Controller: string,
-	Duellist: string,
-	Initiator: string
+  Sentinel: string;
+  Support: string;
+  Controller: string;
+  Duellist: string;
+  Initiator: string;
 }
 
 interface CharacterInfo {
-	Name: string,
-	Type: string,
-	skillActiveName: string,
-	skillActiveDescription: string,
-	skillPassiveName: string,
-	skillPassiveDescription: string,
-	skillUltimateName: string,
-	skillUltimateDescription: string
-	subName: string
-	subDescription: string
+  Name: string;
+  Type: string;
+  skillActiveName: string;
+  skillActiveDescription: string;
+  skillPassiveName: string;
+  skillPassiveDescription: string;
+  skillUltimateName: string;
+  skillUltimateDescription: string;
+  subName: string;
+  subDescription: string;
 }
 
 interface MarkBox {
-	mark: string
-	straightline: string
-	arrowline: string
-	color: string
-	undo: string
-	clear: string
-	clearwarning: {
-		title: string
-		content: string
-		ok: string
-		cancel: string
-		success: string
-		failure: string
-	}
+  mark: string;
+  straightline: string;
+  arrowline: string;
+  color: string;
+  undo: string;
+  clear: string;
+  clearwarning: {
+    title: string;
+    content: string;
+    ok: string;
+    cancel: string;
+    success: string;
+    failure: string;
+  };
 }
 
 interface BugPointSetting {
-	spotmark: string
-	spotmarks: {
-		disable: string
-		available: string
-		all: string
-	}
+  spotmark: string;
+  spotmarks: {
+    disable: string;
+    available: string;
+    all: string;
+  };
 }
 
 interface MobaiSuperJumpSetting {
-	spotmark: string
-	spotmarks: {
-		disable: string
-		available: string
-		all: string
-	}
+  spotmark: string;
+  spotmarks: {
+    disable: string;
+    available: string;
+    all: string;
+  };
 }
 
 interface Skilllineupsetting {
-	spotmark: string
-	spotmarks: Record<string, string>
+  spotmark: string;
+  spotmarks: Record<string, string>;
 }
 
 interface LineupSetting {
-	spotmark: string
-	spotmarks: {
-		disable: string
-		available: string
-		all: string
-	}
+  spotmark: string;
+  spotmarks: {
+    disable: string;
+    available: string;
+    all: string;
+  };
 }
 
 interface MapSetting {
-	choosemap: string
-	maps: {
-		[key in MapName]: string
-	}
-	TeamHighlight: string
-	TeamHighlightOptions: {
-		prepare: string
-		blank: string
-	}
-	Landmarks: string
+  choosemap: string;
+  maps: {
+    [key in MapName]: string;
+  };
+  TeamHighlight: string;
+  TeamHighlightOptions: {
+    prepare: string;
+    blank: string;
+  };
+  Landmarks: string;
 }
 
 interface Sidebar {
-	attact: string
-	defense: string
-	mapsetting: string
-	character: string
-	skill: string
-	grenade: string
-	other: string
-	lineup: string
-	skilllineup: string
-	mobaisuperjump: string
-	bugpoint: string
-	bugpointwarning: JSX.Element
-	learnmore: string
-	supportus: string
-	supportusContent: JSX.Element
+  attact: string;
+  defense: string;
+  mapsetting: string;
+  character: string;
+  skill: string;
+  grenade: string;
+  other: string;
+  lineup: string;
+  skilllineup: string;
+  mobaisuperjump: string;
+  bugpoint: string;
+  bugpointwarning: JSX.Element;
+  learnmore: string;
+  supportus: string;
+  supportusContent: JSX.Element;
 }
 
 interface AnnouncementForm {
-	title: string
-	date: string
-	summary: string
-	data: object
+  title: string;
+  date: string;
+  summary: string;
+  data: object;
 }
 
 interface AnnouncementData {
-	notshowntoday: string
-	pin: AnnouncementForm
-	history: Array<AnnouncementForm> | null | undefined
+  notshowntoday: string;
+  pin: AnnouncementForm;
+  history: Array<AnnouncementForm> | null | undefined;
 }
 
 export interface FriendLinkForm {
-	name: string
-	icon: JSX.Element
-	url: string
+  name: string;
+  icon: JSX.Element;
+  url: string;
 }
 
 interface ClassifyForm {
-	official: string
-	wiki: string
-	others: string
+  official: string;
+  wiki: string;
+  others: string;
 }
 
 interface FriendLinkData {
-	classify: ClassifyForm
-	official: Array<FriendLinkForm>
-	wiki: Array<FriendLinkForm>
-	others: Array<FriendLinkForm>
-	contact: {
-		content: JSX.Element
-	}
+  classify: ClassifyForm;
+  official: Array<FriendLinkForm>;
+  wiki: Array<FriendLinkForm>;
+  others: Array<FriendLinkForm>;
+  contact: {
+    content: JSX.Element;
+  };
 }
 
 export interface SiteListForm {
-	icon: JSX.Element | null | undefined
-	content: string
-	url: string
+  icon: JSX.Element | null | undefined;
+  content: string;
+  url: string;
 }
 
 interface SiteListData {
-	content: JSX.Element
-	Global: Array<SiteListForm>
-	CN: Array<SiteListForm>
+  content: JSX.Element;
+  Global: Array<SiteListForm>;
+  CN: Array<SiteListForm>;
 }
 
 interface SupportUsData {
-	content: JSX.Element
-	global: string
-	CN: string
-	list: string
+  content: JSX.Element;
+  global: string;
+  CN: string;
+  list: string;
 }
 
 export interface I18nData {
-	language: Languages
-	title: string
-	sidebar: Sidebar
-	mapsetting: MapSetting
-	lineupsetting: LineupSetting
-	skilllineupsetting: Skilllineupsetting
-	mobaisuperjumpsetting: MobaiSuperJumpSetting
-	bugpointsetting: BugPointSetting
-	announcement: string
-	friendlink: string
-	sitelist: string
-	announcementdata: AnnouncementData
-	friendlinkdata: FriendLinkData
-	sitelistdata: SiteListData
-	supportusdata: SupportUsData
-	factions: {
-		[key in factions]: string
-	}
-	characters: {
-		PUS: {
-			[key in PUS]: string
-		}
-		TheScissors: {
-			[key in TheScissors]: string
-		}
-		Urbino: {
-			[key in Urbino]: string
-		}
-	}
-	characterInfo: {
-		[key in PUS | TheScissors | Urbino]: CharacterInfo
-	}
-	characterTypes: CharacterTypes
-	grenades: {
-		[key in grenades]: string
-	}
-	others: {
-		[key in others]: string
-	}
-	markbox: MarkBox
+  language: Languages;
+  title: string;
+  sidebar: Sidebar;
+  mapsetting: MapSetting;
+  lineupsetting: LineupSetting;
+  skilllineupsetting: Skilllineupsetting;
+  mobaisuperjumpsetting: MobaiSuperJumpSetting;
+  bugpointsetting: BugPointSetting;
+  announcement: string;
+  friendlink: string;
+  sitelist: string;
+  announcementdata: AnnouncementData;
+  friendlinkdata: FriendLinkData;
+  sitelistdata: SiteListData;
+  supportusdata: SupportUsData;
+  factions: {
+    [key in factions]: string;
+  };
+  characters: {
+    PUS: {
+      [key in PUS]: string;
+    };
+    TheScissors: {
+      [key in TheScissors]: string;
+    };
+    Urbino: {
+      [key in Urbino]: string;
+    };
+  };
+  characterInfo: {
+    [key in PUS | TheScissors | Urbino]: CharacterInfo;
+  };
+  characterTypes: CharacterTypes;
+  grenades: {
+    [key in grenades]: string;
+  };
+  others: {
+    [key in others]: string;
+  };
+  markbox: MarkBox;
 }

--- a/src/utils/canvasConstants.ts
+++ b/src/utils/canvasConstants.ts
@@ -1,27 +1,29 @@
 import { DrawType } from 'pikaso';
 
-export type mapTools = DrawType | "SELECT" | "TEXT";
+export type mapTools = DrawType | 'SELECT' | 'TEXT';
 
 export const colorPalette = [
-	"#FFFFFF",
-	"#000000",
-	"#f44336",
-	"#ffeb3b",
-	"#8bc34a",
-	"#2196f3",
-]
+  '#FFFFFF',
+  '#000000',
+  '#f44336',
+  '#ffeb3b',
+  '#8bc34a',
+  '#2196f3',
+];
 
 export const loadColors = () => {
-	let colors = [...colorPalette]
-	try {
-		const localColors = JSON.parse(localStorage.getItem("colors")||'') as Array<string>
-		if (localColors.length > 0) {
-			colors = localColors
-		}
-	} catch (e) {}
-	return colors
-}
+  let colors = [...colorPalette];
+  try {
+    const localColors = JSON.parse(
+      localStorage.getItem('colors') || '',
+    ) as Array<string>;
+    if (localColors.length > 0) {
+      colors = localColors;
+    }
+  } catch (e) {}
+  return colors;
+};
 
 export const saveColors = (colors: Array<string>) => {
-	localStorage.setItem("colors", JSON.stringify(colors))
-}
+  localStorage.setItem('colors', JSON.stringify(colors));
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});


### PR DESCRIPTION
- close #72 

# Summary

This pr changed these prettier configs and create prettier ignoring list file. And reformat codes.

## Changed configs

- `trailingComma: none` to `all`
  -  It may not affect the behavior of the interpreter, but it is advantageous for searchability of code.
- `semi: false` to `true`
  - js is dangerous because the interpreter may interpret the code differently depending on where the semicolon exists.
- Delete `printWidth: 120` definition
  - [prettier docs](https://prettier.io/docs/options#print-width) have told us that they do not recommend specifying more than 80 characters.
- Delete `tabWidth:2`
  - Since this designation is the same as the default value, it was deemed safe to remove it.

03181108553f36d96d9c59631ec9a1b283e377eb

## prettier formatting ignoring list

Before formatting, I wrote a `.prettierignore` file to ignore the `.github`, `docs`, and `electron` directories that were probably created by the auto-generator.

ec19a36553b97d37b068c91c9d572e2f72a95058

## Format codes

Run `npm run prettier:write`.

f146502f8814c839fe448bb8148d7e647e80c242