### PR TITLE
New PUS defender: Chiyo

### DIFF
--- a/src/data/characters/PUS/Chiyo.tsx
+++ b/src/data/characters/PUS/Chiyo.tsx
@@ -4,6 +4,9 @@ import { factions, PUS } from '../factions';
 const character: characterData = {
   faction: factions.PUS,
   id: PUS.Chiyo,
+  /**
+   * TODO: This image links are mock. Pls impl chiyo images.
+   */
   defense: {
     canvasImage: 'https://s2.loli.net/2024/09/29/jC98Rq3NhrUXYWK.png',
     bodyImage: 'https://cdn.sa.net/2025/04/22/ZcVRCBUJ8PGwn46.png',

--- a/src/data/characters/PUS/Chiyo.tsx
+++ b/src/data/characters/PUS/Chiyo.tsx
@@ -1,0 +1,47 @@
+import { characterData } from '../characterRegistry';
+import { factions, PUS } from '../factions';
+
+const character: characterData = {
+  faction: factions.PUS,
+  id: PUS.Chiyo,
+  defense: {
+    canvasImage: 'https://s2.loli.net/2024/09/29/jC98Rq3NhrUXYWK.png',
+    bodyImage: 'https://cdn.sa.net/2025/04/22/ZcVRCBUJ8PGwn46.png',
+    skills: {
+      active: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/58dg6OpPntlviqW.png',
+        generateOnCanvas: active,
+      },
+      passive: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/u5tV9xaNyjUL6EM.png',
+        generateOnCanvas: passive,
+      },
+      ultimate: {
+        skillIcon: 'https://s2.loli.net/2024/09/25/ezsVQS62bY5iBcG.png',
+        generateOnCanvas: ultimate,
+      },
+      sub: {
+        skillIcon: 'https://cdn.sa.net/2024/11/19/lYbBufA6raXvQ1n.png',
+        generateOnCanvas: sub,
+      },
+    },
+  },
+};
+
+function active() {
+  return;
+}
+
+function passive() {
+  return;
+}
+
+function ultimate() {
+  return;
+}
+
+function sub() {
+  return;
+}
+
+export default character;

--- a/src/data/characters/factions.ts
+++ b/src/data/characters/factions.ts
@@ -12,6 +12,7 @@ export enum PUS {
   Flavia = 'Flavia',
   Yugiri = 'Yugiri',
   Leona = 'Leona',
+  Chiyo = 'Chiyo',
 }
 
 export enum TheScissors {

--- a/src/data/languages/en_US.tsx
+++ b/src/data/languages/en_US.tsx
@@ -272,6 +272,7 @@ export default {
       Flavia: 'Flavia',
       Yugiri: 'Yugiri',
       Leona: 'Leona',
+      Chiyo: 'Chiyo',
     },
     TheScissors: {
       Ming: 'Ming',
@@ -376,6 +377,22 @@ export default {
       skillUltimateDescription: `Leona fills her energy bar, making existing and newly generated blocks permanently transparent during the skill duration. Transparent blocks no longer block paths or ally bullets.`,
       subName: `防弹护窗`,
       subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
+    },
+    Chiyo: {
+      Name: 'Chiyo',
+      Type: 'Duelist',
+      skillActiveName: 'Burst of Brilliance',
+      skillActiveDescription:
+        'Fire an explosive arrow that sticks to surfaces, which can be detonated early or auto-detonates when its duration ends.',
+      skillPassiveName: 'Steady Resolve',
+      skillPassiveDescription:
+        'Steadily regain Focus, with recovery slowing briefly after attacks. When full, Focus is consumed to boost DMG briefly.',
+      skillUltimateName: 'Skyshatter',
+      skillUltimateDescription:
+        'Temporarily reveal enemies near allies and fire a charged wall-piercing explosive arrow at the target. The arrow explodes upon reaching max range or hitting an enemy.',
+      subName: 'Cloudpiercer',
+      subDescription:
+        'Charge and fire an arrow at the target, dealing high DMG and a rapidly fading slow effect based on the impact point.',
     },
     Ming: {
       Name: 'Ming',

--- a/src/data/languages/ja_JP.tsx
+++ b/src/data/languages/ja_JP.tsx
@@ -267,11 +267,12 @@ export default {
       Kokona: '心夏',
       Yvette: 'イヴェット',
       Flavia: 'フラヴィア',
-      Yugiri: 'Yugiri',
-      Leona: 'Leona',
+      Yugiri: '夕霧',
+      Leona: 'レオナ',
+      Chiyo: '千代',
     },
     TheScissors: {
-      Ming: 'ミン',
+      Ming: '明',
       Lawine: 'ラヴィーネ',
       Meredith: 'メレディス',
       Reiichi: '令一',
@@ -373,6 +374,22 @@ export default {
       skillUltimateDescription: `蕾欧娜充满弦能条，场上已存在方块和技能持续期间生成的方块永久变透明，透明方块将不再阻挡通路与友方子弹。`,
       subName: `防弹护窗`,
       subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
+    },
+    Chiyo: {
+      Name: '千代',
+      Type: 'デュエリスト',
+      skillActiveName: '刹那の華',
+      skillActiveDescription:
+        '建物の表面に付着する爆発矢を放つ。矢は任意のタイミングで起爆でき、最大持続時間に達すると自動的に爆発する',
+      skillPassiveName: '明鏡止水',
+      skillPassiveDescription:
+        '時間経過で集中力を回復し、攻撃すると一時的に回復速度が低下する。集中力が最大のとき、攻撃で集中力を消費し、一定時間自身の火力が強化される',
+      skillUltimateName: '紅焔・崩天',
+      skillUltimateDescription:
+        '味方の近くにいる敵を透視し、チャージ後に壁を貫通する爆発矢を発射する。矢はチャージ時間に応じた距離を飛んで停止し、着弾地点で短時間の遅延の後に爆発して周囲に大ダメージを与える',
+      subName: '雲貫の矢',
+      subDescription:
+        'チャージ後、貫通矢を目標方向へ放ち、軌道上の敵に高ダメージとスロウ効果を与える',
     },
     Ming: {
       Name: '明',

--- a/src/data/languages/zh_CN.tsx
+++ b/src/data/languages/zh_CN.tsx
@@ -280,6 +280,7 @@ export default {
       Flavia: '芙拉薇娅',
       Yugiri: '忧雾',
       Leona: '雷欧娜',
+      Chiyo: '千代',
     },
     TheScissors: {
       Ming: '明',
@@ -384,6 +385,22 @@ export default {
       skillUltimateDescription: `蕾欧娜充满弦能条，场上已存在方块和技能持续期间生成的方块永久变透明，透明方块将不再阻挡通路与友方子弹。`,
       subName: `防弹护窗`,
       subDescription: `蕾欧娜在已放置的方块表面横或纵向放置单向防弹玻璃。玻璃不可阻挡行进或技能，仅阻挡敌方子弹。玻璃生成会消耗技能点数及弦能条。防弹玻璃最多同时存在3个。`,
+    },
+    Chiyo: {
+      Name: '千代',
+      Type: '决斗',
+      skillActiveName: '爆绽瞬华',
+      skillActiveDescription:
+        '射出一发可附着在建筑表面的爆炸箭，爆炸箭可以被提前引爆，或在到达最大存在时间后自行爆炸',
+      skillPassiveName: '静心凝势',
+      skillPassiveDescription:
+        '持续恢复专注度，进行攻击后会短暂减缓恢复速度;满专注值时，造成伤害后会消耗专注值并在一段时间内强化自身输出',
+      skillUltimateName: '枫烬崩天',
+      skillUltimateDescription:
+        '短暂透视队友附近的敌人，并且在蓄力后向目标方向发射可以穿透墙体的爆炸箭。箭矢在到达最大飞行距离或命中敌人后爆炸',
+      subName: '滞影贯云',
+      subDescription:
+        '蓄力后向目标方向发射一支狙击箭矢，根据命中部位造成高额伤害并造成迅速衰退的减速效果',
     },
     Ming: {
       Name: '明',


### PR DESCRIPTION
**This pr is now WIP!**

### Tasks

- [ ] Replace TODO image links to Chiyo images

# Summary

This PR implements the addition of Chiyo, the new PUS Duelist added in https://www.strinova.com/ja-JP/news/_5OWl4RuJOUv1ZfiFXRmaw%7D .
Text such as skill descriptions in Japanese, Chinese, and English has been filled in.

The text has been quoted from the following two sites:

- https://www.strinovajp-wiki.jp/chiyo
  - Japanese
- https://strinova.org/wiki/Chiyo
  - Chinese
  - English

We have confirmed that the Japanese and English text displays correctly.

<img width="1312" height="361" alt="Screenshot_20250902_191045" src="https://github.com/user-attachments/assets/719ddf76-f3a7-4293-bba1-9c4306dd90ac" />


Additionally, we have taken the opportunity to fix some areas that were not previously translated into Japanese.


